### PR TITLE
ADEN-8842 AdSlot getTopOffset handles no slot element.

### DIFF
--- a/spec/ad-engine/models/ad-slot.spec.ts
+++ b/spec/ad-engine/models/ad-slot.spec.ts
@@ -154,10 +154,10 @@ describe('ad-slot', () => {
 			adSlot = createAdSlot('top_leaderboard');
 		});
 
-		it('should return -1 if getElement returns null', () => {
+		it('should return null if getElement returns null', () => {
 			adSlot.getElement = () => null;
 
-			expect(adSlot.getTopOffset()).to.equal(-1);
+			expect(adSlot.getTopOffset()).to.equal(null);
 		});
 	});
 });

--- a/spec/ad-engine/models/ad-slot.spec.ts
+++ b/spec/ad-engine/models/ad-slot.spec.ts
@@ -1,3 +1,4 @@
+import { Dictionary } from '@wikia/ad-engine';
 import { expect } from 'chai';
 import { AdSlot } from '../../../src/ad-engine/models/ad-slot';
 import { context } from '../../../src/ad-engine/services/context-service';
@@ -115,10 +116,8 @@ describe('ad-slot', () => {
 	});
 
 	describe('updateWinningA9BidderDetails', () => {
-		/** @type {AdSlot} */
-		let adSlot;
-		/** @type {Object} */
-		let targeting;
+		let adSlot: AdSlot;
+		let targeting: Dictionary;
 
 		beforeEach(() => {
 			adSlot = createAdSlot('top_leaderboard');
@@ -145,6 +144,20 @@ describe('ad-slot', () => {
 			adSlot.updateWinningA9BidderDetails();
 
 			expect(adSlot.winningBidderDetails).to.be.null;
+		});
+	});
+
+	describe('getTopOffset', () => {
+		let adSlot: AdSlot;
+
+		beforeEach(() => {
+			adSlot = createAdSlot('top_leaderboard');
+		});
+
+		it('should return -1 if getElement returns null', () => {
+			adSlot.getElement = () => null;
+
+			expect(adSlot.getTopOffset()).to.equal(-1);
 		});
 	});
 });

--- a/src/ad-engine/models/ad-slot.ts
+++ b/src/ad-engine/models/ad-slot.ts
@@ -225,8 +225,15 @@ export class AdSlot extends EventEmitter {
 		return JSON.parse(JSON.stringify(this.config));
 	}
 
+	/**
+	 * Returns offset of slot from top of the page.
+	 *
+	 * Returns -1 if slot has no element.
+	 */
 	getTopOffset(): number {
-		return getTopOffset(this.getElement());
+		const element = this.getElement();
+
+		return element ? getTopOffset(element) : -1;
 	}
 
 	enable(): void {

--- a/src/ad-engine/models/ad-slot.ts
+++ b/src/ad-engine/models/ad-slot.ts
@@ -228,12 +228,12 @@ export class AdSlot extends EventEmitter {
 	/**
 	 * Returns offset of slot from top of the page.
 	 *
-	 * Returns -1 if slot has no element.
+	 * Returns null if slot has no element.
 	 */
-	getTopOffset(): number {
+	getTopOffset(): number | null {
 		const element = this.getElement();
 
-		return element ? getTopOffset(element) : -1;
+		return element ? getTopOffset(element) : null;
 	}
 
 	enable(): void {


### PR DESCRIPTION
If slot has no element, then it returns -1.