### PR TITLE
ADEN-9031 Add no-unused-variable rule as error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
 			"*.ts": [
 				"prettier --write",
 				"tslint --fix",
+				"npm run check-types:selected",
 				"git add"
 			],
 			"*.{js,json,css,scss,html}": [

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 		"allure-clear": "find ./tests/allure-results/ -name *attachment.json -delete; find ./tests/allure-results/ -name *testsuite.xml -delete; find ./tests/allure-results/ -name *attachment.png -delete",
 		"check-types": "tsc -noEmit",
 		"check-types:watch": "tsc --watch -noEmit",
-		"check-types:selected": "npm run check-types 2> /dev/null | grep -e src/ad-engine -e src/ad-bidders -e src/ad-services -e @types | grep -v npm",
+		"check-types:selected": "npm run check-types 2> /dev/null | grep -e src/ad-engine -e src/ad-bidders -e src/ad-services -e src/ad-tracking -e @types | grep -v npm",
 		"rules:build": "tsc --project 'maintenance/tslint-rules/tsconfig.json'",
 		"rules:test": "tslint --project 'maintenance/tslint-rules/tests/tsconfig.json'",
 		"rules:lint": "tslint --project 'maintenance/tslint-rules/tsconfig.json'",
@@ -148,7 +148,7 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "lint-staged && if npm run check-types 2> /dev/null | grep -e src/ad-engine -e src/ad-bidders -e src/ad-services -e @types | grep -v npm; then exit 1; fi"
+			"pre-commit": "lint-staged && if npm run check-types 2> /dev/null | grep -e src/ad-engine -e src/ad-bidders -e src/ad-services -e src/ad-tracking -e @types | grep -v npm; then exit 1; fi"
 		}
 	},
 	"lint-staged": {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 		"allure-clear": "find ./tests/allure-results/ -name *attachment.json -delete; find ./tests/allure-results/ -name *testsuite.xml -delete; find ./tests/allure-results/ -name *attachment.png -delete",
 		"check-types": "tsc -noEmit",
 		"check-types:watch": "tsc --watch -noEmit",
-		"check-types:selected": "npm run check-types 2> /dev/null | grep -e src/ad-engine -e src/ad-bidders -e @types | grep -v npm",
+		"check-types:selected": "npm run check-types 2> /dev/null | grep -e src/ad-engine -e src/ad-bidders -e src/ad-services -e @types | grep -v npm",
 		"rules:build": "tsc --project 'maintenance/tslint-rules/tsconfig.json'",
 		"rules:test": "tslint --project 'maintenance/tslint-rules/tests/tsconfig.json'",
 		"rules:lint": "tslint --project 'maintenance/tslint-rules/tsconfig.json'",
@@ -148,7 +148,7 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "lint-staged && if npm run check-types 2> /dev/null | grep -e src/ad-engine -e src/ad-bidders -e @types | grep -v npm; then exit 1; fi"
+			"pre-commit": "lint-staged && if npm run check-types 2> /dev/null | grep -e src/ad-engine -e src/ad-bidders -e src/ad-services -e @types | grep -v npm; then exit 1; fi"
 		}
 	},
 	"lint-staged": {

--- a/spec/tslint.json
+++ b/spec/tslint.json
@@ -2,7 +2,6 @@
 	"extends": "../tslint.json",
 	"rules": {
 		"no-console": false,
-		"no-unused-variable": false,
 		"no-unused-expression": false,
 		"no-implicit-dependencies": [true, "dev", ["@wikia"]],
 		"no-submodule-imports": false,

--- a/src/ad-bidders/index.ts
+++ b/src/ad-bidders/index.ts
@@ -1,8 +1,6 @@
 import { context, Dictionary, events, eventService, utils } from '@wikia/ad-engine';
 import { A9 } from './a9';
-import { BidsBackHandler } from './base-bidder';
 import { Prebid } from './prebid';
-import { AdUnitConfig } from './prebid/adapters';
 import * as prebidHelper from './prebid/prebid-helper';
 import { transformPriceFromBid } from './prebid/price-helper';
 

--- a/src/ad-bidders/wrappers/apstag.ts
+++ b/src/ad-bidders/wrappers/apstag.ts
@@ -16,7 +16,6 @@ export class Apstag {
 
 	private renderImpEndCallbacks = [];
 	private renderImpHookPresent = false;
-	private script: Promise<Event>;
 	utils = utils;
 
 	/**
@@ -31,7 +30,7 @@ export class Apstag {
 	 * @private
 	 */
 	insertScript() {
-		this.script = this.utils.scriptLoader.loadScript(
+		this.utils.scriptLoader.loadScript(
 			'//c.amazon-adsystem.com/aax2/apstag.js',
 			'text/javascript',
 			true,

--- a/src/ad-engine/listeners/slot-listener.ts
+++ b/src/ad-engine/listeners/slot-listener.ts
@@ -1,5 +1,5 @@
 import { AdSlot, Dictionary } from '../models';
-import { context, eventService, slotInjector, slotTweaker } from '../services';
+import { context, eventService, slotTweaker } from '../services';
 import { client, logger } from '../utils';
 
 interface AdditionalEventData {

--- a/src/ad-engine/utils/geo.ts
+++ b/src/ad-engine/utils/geo.ts
@@ -11,7 +11,6 @@ const samplingSeparator = '/';
 const sessionCookieDefault = 'tracking_session_id';
 let cache: CacheDictionary = {};
 let cookieLoaded = false;
-const geoData: GeoData | {} = null;
 
 export interface CacheDictionary {
 	[key: string]: CacheData;

--- a/src/ad-engine/utils/not-implemented-exception.ts
+++ b/src/ad-engine/utils/not-implemented-exception.ts
@@ -1,6 +1,6 @@
 export class NotImplementedException extends Error {
-	// tslint:disable-next-line: no-unused-variable
-	private parameters: {};
+	// @ts-ignore
+	private parameters: object;
 
 	/**
 	 * @param parameters - pass here method input parameters as an object.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
 		"resolveJsonModule": true,
 		"noImplicitAny": false,
 		"baseUrl": "src",
+		"noUnusedLocals": true,
 		"paths": {
 			"@wikia/ad-engine": ["ad-engine"],
 			"@wikia/ad-tracking": ["ad-tracking"]


### PR DESCRIPTION
Run type check for ad-engine and ad-bidders on commit.

I removed obsolete "no-unused-locals" setting from tslint config.

I added check of types (in ad-engine and ad-bidders) on commit to ensure that we do not introduce new errors there.