### PR TITLE
ADEN-10326 Set correct src for test environments with testSrc set

### DIFF
--- a/platforms/shared/context/targeting/ucp-targeting.setup.ts
+++ b/platforms/shared/context/targeting/ucp-targeting.setup.ts
@@ -19,7 +19,9 @@ export class UcpTargetingSetup implements TargetingSetup {
 	configureTargetingContext(): void {
 		context.set('targeting', { ...context.get('targeting'), ...this.getPageLevelTargeting() });
 
-		if (context.get('wiki.opts.isAdTestWiki')) {
+		if (context.get('wiki.opts.isAdTestWiki') && context.get('wiki.targeting.testSrc')) {
+			context.set('src', context.get('wiki.targeting.testSrc'));
+		} else if (context.get('wiki.opts.isAdTestWiki')) {
 			context.set('src', 'test');
 		}
 	}


### PR DESCRIPTION
In Oasis we have this logic at the phase when we set up the ad context in JS: https://github.com/Wikia/app/blob/6f029810527f757dea0b6d678f933542d59ff8bb/extensions/wikia/AdEngine3/src/setup.js#L76

Docs: https://wikia-inc.atlassian.net/wiki/spaces/ADEN/pages/1009549793/External+test+and+showcase

Linked PR: https://github.com/Wikia/unified-platform/pull/2516