### PR TITLE
GPUCP-471 | Fix hiding advertisements for all Hydra skins.

### DIFF
--- a/platforms/gamepedia/styles.scss
+++ b/platforms/gamepedia/styles.scss
@@ -32,7 +32,7 @@
 }
 
 // Desktop disable ads
-html.disable-ads {
+html.disable-ads, body.hide-ads {
 	#pageWrapper {
 		#atflb,
 		#btflb {


### PR DESCRIPTION
The `body.hide-ads` class is used to hide advertisements for all Hydra skins when the user has the appropriate entitlement.

https://wikia-inc.atlassian.net/browse/GPUCP-471