### PR TITLE
[UCP] Use services.fandom.com for bill-the-lizard and ICBM

### DIFF
--- a/platforms/ucp-mobile/ad-context.ts
+++ b/platforms/ucp-mobile/ad-context.ts
@@ -72,7 +72,7 @@ export const basicContext = {
 			endpoint: '/wikia.php?controller=AdEngine&method=postLog',
 		},
 		instantConfig: {
-			endpoint: 'https://services.wikia.com/icbm/api/config?app=mobile-wiki',
+			endpoint: 'https://services.fandom.com/icbm/api/config?app=mobile-wiki',
 			fallback: fallbackInstantConfig,
 		},
 		iasPublisherOptimization: {

--- a/platforms/ucp-no-ads/setup/wiki-context.setup.ts
+++ b/platforms/ucp-no-ads/setup/wiki-context.setup.ts
@@ -6,7 +6,7 @@ export class UcpNoAdsWikiContextSetup implements DiProcess {
 			window.ads.context && window.ads.context.opts.platformName
 				? window.ads.context.opts.platformName
 				: '';
-		const endpoint = `https://services.wikia.com/icbm/api/config?app=${platformName}`;
+		const endpoint = `https://services.fandom.com/icbm/api/config?app=${platformName}`;
 
 		context.set('services.instantConfig.endpoint', endpoint);
 	}

--- a/platforms/ucp/ad-context.ts
+++ b/platforms/ucp/ad-context.ts
@@ -57,7 +57,7 @@ export const basicContext = {
 	services: {
 		billTheLizard: {
 			enabled: true,
-			host: 'https://services.wikia.com',
+			host: 'https://services.fandom.com',
 			endpoint: 'bill-the-lizard/predict',
 			projects: {},
 			parameters: {},
@@ -90,7 +90,7 @@ export const basicContext = {
 			endpoint: '/wikia.php?controller=AdEngine&method=postLog',
 		},
 		instantConfig: {
-			endpoint: 'https://services.wikia.com/icbm/api/config?app=oasis',
+			endpoint: 'https://services.fandom.com/icbm/api/config?app=oasis',
 			fallback: fallbackInstantConfig,
 		},
 		nielsen: {


### PR DESCRIPTION
Currently, ad-engine uses services.wikia.com domain to call bill-the-lizard and ICBM endpoints, which necessitates another network connection and TLS handshake. Let's use services.fandom.com domain instead, which is already being used by other UCP FE clients.