### PR TITLE
ADEN-11118 Distroscale changes on FandomDesktop

### DIFF
--- a/platforms/ucp-desktop/setup/state/slots/ucp-desktop-slots-state-setup.ts
+++ b/platforms/ucp-desktop/setup/state/slots/ucp-desktop-slots-state-setup.ts
@@ -5,6 +5,8 @@ import {
 	context,
 	DiProcess,
 	distroScale,
+	getAdUnitString,
+	globalRuntimeVariableSetter,
 	InstantConfigService,
 	ofType,
 	slotDataParamsUpdater,
@@ -45,8 +47,22 @@ export class UcpDesktopSlotsStateSetup implements DiProcess {
 		}
 	}
 
+	private setDistroscaleVarInRuntime(slotName: string): void {
+		const params = {
+			group: 'VIDEO',
+			adProduct: 'incontent_video',
+			slotNameSuffix: '',
+		};
+
+		const distroscaleIU = getAdUnitString(slotName, params);
+
+		globalRuntimeVariableSetter.addNewVariableToRuntime('distroscale', { adUnit: distroscaleIU });
+	}
+
 	private setupIncontentPlayerForDistroScale(): void {
 		const slotName = 'incontent_player';
+		this.setDistroscaleVarInRuntime(slotName);
+		context.set('slots.incontent_player.targeting.pos', ['incontent_video']);
 
 		slotService.setState(slotName, false, AdSlot.STATUS_COLLAPSE);
 		slotService.on(slotName, AdSlot.STATUS_COLLAPSE, () => {


### PR DESCRIPTION
It's a P2 fix before we get with FandomDesktop on a bigger scale. There is room for improvement since now the same code is in at least two places. On the other hand, it may make sense from the business point of view if we don't want to have the player enabled on other platforms.