### PR TITLE
ADEN-11342 - Remove slot: invisible_skin

### DIFF
--- a/platforms/shared/templates/handlers/roadblock/roadblock-handler.ts
+++ b/platforms/shared/templates/handlers/roadblock/roadblock-handler.ts
@@ -1,5 +1,4 @@
 import {
-	context,
 	TEMPLATE,
 	TemplateDependency,
 	TemplateStateHandler,
@@ -32,6 +31,5 @@ export class RoadblockHandler implements TemplateStateHandler {
 	async onEnter(): Promise<void> {
 		this.params.adProduct = 'ruap';
 		universalAdPackage.init(this.params as any, this.config.enabledSlots, this.config.disableSlots);
-		context.push('state.adStack', { id: 'invisible_skin' });
 	}
 }

--- a/platforms/ucp-desktop/setup/context/slots/ucp-desktop-slots-context.setup.ts
+++ b/platforms/ucp-desktop/setup/context/slots/ucp-desktop-slots-context.setup.ts
@@ -99,29 +99,6 @@ export class UcpDesktopSlotsContextSetup implements DiProcess {
 					rv: 1,
 				},
 			},
-			invisible_skin: {
-				adProduct: 'invisible_skin',
-				aboveTheFold: true,
-				group: 'PX',
-				insertBeforeSelector: '.page',
-				options: {},
-				slotNameSuffix: '',
-				slotShortcut: 'x',
-				sizes: [
-					{
-						viewportSize: [1240, 0],
-						sizes: [
-							[1, 1],
-							[1000, 1000],
-						],
-					},
-				],
-				defaultSizes: [[1, 1]],
-				targeting: {
-					loc: 'top',
-					rv: 1,
-				},
-			},
 			incontent_boxad_1: {
 				adProduct: 'incontent_boxad_1',
 				bidderAlias: 'incontent_boxad_1',

--- a/platforms/ucp-desktop/setup/state/slots/ucp-desktop-slots-state-setup.ts
+++ b/platforms/ucp-desktop/setup/state/slots/ucp-desktop-slots-state-setup.ts
@@ -20,7 +20,6 @@ export class UcpDesktopSlotsStateSetup implements DiProcess {
 		slotsContext.setState('top_boxad', this.isRightRailApplicable());
 		slotsContext.setState('affiliate_slot', this.isAffiliateSlotEnabled());
 		slotsContext.setState('bottom_leaderboard', true);
-		slotsContext.setState('invisible_skin', false);
 		slotsContext.setState(
 			'floor_adhesion',
 			this.instantConfig.get('icFloorAdhesion') && !context.get('custom.hasFeaturedVideo'),

--- a/platforms/ucp-desktop/styles.scss
+++ b/platforms/ucp-desktop/styles.scss
@@ -156,10 +156,6 @@
 	margin: 0 10px 10px 0 !important;
 }
 
-#invisible_skin {
-	display: none !important;
-}
-
 #affiliate_slot > div {
 	margin: 0 10px 10px;
 }

--- a/platforms/ucp-desktop/templates/roadblock-template.ts
+++ b/platforms/ucp-desktop/templates/roadblock-template.ts
@@ -11,7 +11,7 @@ export function registerRoadblockTemplate(registry: TemplateRegistry): Observabl
 		'initial',
 		[
 			RoadblockHandler.config({
-				enabledSlots: ['top_boxad', 'invisible_skin'],
+				enabledSlots: ['top_boxad'],
 				disableSlots: ['incontent_player', 'floor_adhesion', 'affiliate_slot'],
 			}),
 		],

--- a/spec/ad-engine/config-mock.ts
+++ b/spec/ad-engine/config-mock.ts
@@ -13,15 +13,27 @@ export default {
 			sizes: [
 				{
 					viewportSize: [1440, 350],
-					sizes: [[728, 90], [970, 250], [1024, 416], [1440, 585]],
+					sizes: [
+						[728, 90],
+						[970, 250],
+						[1024, 416],
+						[1440, 585],
+					],
 				},
 				{
 					viewportSize: [1024, 300],
-					sizes: [[728, 90], [970, 250], [1024, 416]],
+					sizes: [
+						[728, 90],
+						[970, 250],
+						[1024, 416],
+					],
 				},
 				{
 					viewportSize: [970, 200],
-					sizes: [[728, 90], [970, 250]],
+					sizes: [
+						[728, 90],
+						[970, 250],
+					],
 				},
 				{
 					viewportSize: [728, 200],
@@ -29,14 +41,22 @@ export default {
 				},
 				{
 					viewportSize: [320, 200],
-					sizes: [[300, 250], [320, 480]],
+					sizes: [
+						[300, 250],
+						[320, 480],
+					],
 				},
 				{
 					viewportSize: [0, 0],
 					sizes: [[300, 250]],
 				},
 			],
-			defaultSizes: [[728, 90], [970, 250], [1024, 416], [1440, 585]],
+			defaultSizes: [
+				[728, 90],
+				[970, 250],
+				[1024, 416],
+				[1440, 585],
+			],
 			targeting: {
 				loc: 'top',
 			},
@@ -46,7 +66,10 @@ export default {
 			sizes: [
 				{
 					viewportSize: [1024, 300],
-					sizes: [[728, 90], [1024, 416]],
+					sizes: [
+						[728, 90],
+						[1024, 416],
+					],
 				},
 				{
 					viewportSize: [728, 100],
@@ -72,10 +95,18 @@ export default {
 				},
 				{
 					viewportSize: [768, 200],
-					sizes: [[300, 250], [300, 600], [300, 1050]],
+					sizes: [
+						[300, 250],
+						[300, 600],
+						[300, 1050],
+					],
 				},
 			],
-			defaultSizes: [[300, 250], [300, 600], [300, 1050]],
+			defaultSizes: [
+				[300, 250],
+				[300, 600],
+				[300, 1050],
+			],
 			targeting: {
 				loc: 'top',
 			},
@@ -89,10 +120,16 @@ export default {
 				},
 				{
 					viewportSize: [768, 200],
-					sizes: [[300, 250], [300, 600]],
+					sizes: [
+						[300, 250],
+						[300, 600],
+					],
 				},
 			],
-			defaultSizes: [[300, 250], [300, 600]],
+			defaultSizes: [
+				[300, 250],
+				[300, 600],
+			],
 			defaultTemplate: 'floating-ad',
 			targeting: {
 				loc: 'hivi',
@@ -106,29 +143,20 @@ export default {
 				},
 				{
 					viewportSize: [768, 200],
-					sizes: [[300, 250], [300, 600], [300, 1050]],
+					sizes: [
+						[300, 250],
+						[300, 600],
+						[300, 1050],
+					],
 				},
 			],
-			defaultSizes: [[300, 250], [300, 1050], [300, 600]],
+			defaultSizes: [
+				[300, 250],
+				[300, 1050],
+				[300, 600],
+			],
 			targeting: {
 				loc: 'bottom',
-			},
-		},
-		invisible_skin: {
-			aboveTheFold: true,
-			sizes: [
-				{
-					viewportSize: [1064, 600],
-					sizes: [[1000, 1000]],
-				},
-				{
-					viewportSize: [0, 0],
-					sizes: [],
-				},
-			],
-			defaultSizes: [[1000, 1000]],
-			targeting: {
-				loc: 'top',
 			},
 		},
 		incontent_player: {

--- a/spec/ad-engine/models/ad-slot.spec.ts
+++ b/spec/ad-engine/models/ad-slot.spec.ts
@@ -57,13 +57,6 @@ describe('ad-slot', () => {
 		expect(adSlot.getAdUnit()).to.equal('/5441/something/_article/top_boxad');
 	});
 
-	it('with other ad unit', () => {
-		context.set('custom.pageType', 'other');
-		const adSlot = createAdSlot('INVISIBLE_SKIN');
-
-		expect(adSlot.getAdUnit()).to.equal('/5441/something/_other/INVISIBLE_SKIN');
-	});
-
 	it('config property getter and setter', () => {
 		const adSlot = createAdSlot('top_boxad');
 


### PR DESCRIPTION
## Links:
https://fandom.atlassian.net/browse/ADEN-11342

## Description
Slot _invisible_skin_ is no longer used, so it should be removed from AdEngine.