### PR TITLE
ADEN-11503 Bring back blacklisted imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+	"root": true,
 	"env": {
 		"browser": true,
 		"es2021": true

--- a/platforms/.eslintrc.json
+++ b/platforms/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["./../.eslintrc.json"],
+	"rules": {
+		"no-restricted-imports": [
+			"error",
+			{ "paths": ["@wikia/ad-engine", "@platforms/shared", "@platforms/shared-sports"] }
+		]
+	}
+}

--- a/platforms/.eslintrc.json
+++ b/platforms/.eslintrc.json
@@ -1,9 +1,6 @@
 {
-	"extends": ["./../.eslintrc.json"],
+	"extends": ["../.eslintrc.json"],
 	"rules": {
-		"no-restricted-imports": [
-			"error",
-			{ "paths": ["@wikia/ad-engine", "@platforms/shared", "@platforms/shared-sports"] }
-		]
+		"no-restricted-imports": ["error", { "paths": ["/src"] }]
 	}
 }

--- a/platforms/.eslintrc.json
+++ b/platforms/.eslintrc.json
@@ -1,6 +1,11 @@
 {
 	"extends": ["../.eslintrc.json"],
 	"rules": {
-		"no-restricted-imports": ["error", { "paths": ["/src"] }]
+		"no-restricted-imports": [
+			"error",
+			{
+				"patterns": ["**/src/**"]
+			}
+		]
 	}
 }

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -1,7 +1,7 @@
 {
 	"extends": ["./../.eslintrc.json"],
 	"rules": {
-		"no-console": "error"
-		//    "no-unused-expressions": "error"
+		"no-console": "error",
+		"@typescript-eslint/no-empty-function": "off"
 	}
 }

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["./../.eslintrc.json"],
+	"rules": {
+		"no-console": "error"
+		//    "no-unused-expressions": "error"
+	}
+}

--- a/spec/ad-engine/ad-slot-fake.ts
+++ b/spec/ad-engine/ad-slot-fake.ts
@@ -90,9 +90,7 @@ export const adSlotFake = {
 			dataset,
 			offsetTop,
 			classList: {
-				contains: () => {
-					// noop for tests
-				},
+				contains: () => {},
 			},
 			offsetHeight: 300,
 			getBoundingClientRect: () => ({

--- a/spec/ad-engine/listeners/porvata-listener.spec.ts
+++ b/spec/ad-engine/listeners/porvata-listener.spec.ts
@@ -88,9 +88,7 @@ describe('porvata-listener', () => {
 	it('dispatch video viewed event on ad-slot', () => {
 		const listener = new PorvataListener({ adProduct: 'test-video', position: 'abcd' } as any);
 
-		const adSlotMock = { emit: spy(), getSlotName: () => {
-			// noop for tests
-		} };
+		const adSlotMock = { emit: spy(), getSlotName: () => {} };
 
 		sandbox.stub(slotService, 'get').returns(adSlotMock);
 

--- a/spec/ad-engine/listeners/scroll-listener.spec.ts
+++ b/spec/ad-engine/listeners/scroll-listener.spec.ts
@@ -12,9 +12,7 @@ describe('ScrollListener', () => {
 		getElementByIdStub = sinon.stub(document, 'getElementById');
 		getElementByIdStub.callsFake(() => 'fakeNode');
 		addCallbackStub = sinon.stub(scrollListener, 'addCallback');
-		addCallbackStub.callsFake(() => {
-			// noop for tests
-		});
+		addCallbackStub.callsFake(() => {});
 	});
 
 	afterEach(() => {

--- a/spec/ad-engine/runner/runner.spec.ts
+++ b/spec/ad-engine/runner/runner.spec.ts
@@ -31,9 +31,7 @@ describe('runner', () => {
 	});
 
 	it('resolves itself after timeout when there are no resolved inhibitors', async () => {
-		const runner = new Runner([new Promise(() => {
-			// noop for tests
-		})], defaultTimeout);
+		const runner = new Runner([new Promise(() => {})], defaultTimeout);
 		const runnerPromise = runner
 			.waitForInhibitors()
 			.then(() => (resolveTime = new Date().getTime()));

--- a/spec/ad-engine/services/context-service.spec.ts
+++ b/spec/ad-engine/services/context-service.spec.ts
@@ -2,9 +2,7 @@ import { context } from '@wikia/ad-engine';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
 
-function baz(): void {
-	// noop for tests
-}
+function baz(): void {}
 
 describe('context-service', () => {
 	const sandbox = createSandbox();

--- a/spec/ad-engine/services/slot-injector.spec.ts
+++ b/spec/ad-engine/services/slot-injector.spec.ts
@@ -24,9 +24,7 @@ describe('slot-injector', () => {
 		conflictingElement = {
 			getBoundingClientRect: () => ({ top: 0, left: 0 }),
 			classList: {
-				contains: () => {
-					// noop for tests
-				},
+				contains: () => {},
 			},
 			offsetHeight: 300,
 			offsetTop: 1400,
@@ -37,17 +35,13 @@ describe('slot-injector', () => {
 		placeholder = {
 			getBoundingClientRect: () => ({ top: 0, left: 0 }),
 			classList: {
-				contains: () => {
-					// noop for tests
-				},
+				contains: () => {},
 			},
 			offsetHeight: 300,
 			offsetTop: 1500,
 			offsetParent: elementProperties.offsetParent,
 			ownerDocument: {},
-			before: () => {
-				// noop for tests
-			},
+			before: () => {},
 		};
 
 		const querySelectorAll = sandbox.stub(document, 'querySelectorAll');

--- a/spec/ad-engine/services/slot-service.spec.ts
+++ b/spec/ad-engine/services/slot-service.spec.ts
@@ -46,9 +46,7 @@ describe('slot-service', () => {
 			.withArgs('foo-container')
 			.returns({
 				classList: {
-					contains: () => {
-						// noop for tests
-					},
+					contains: () => {},
 				},
 				getBoundingClientRect: () => ({ top: 0, left: 0 } as any),
 				offsetHeight: 300,

--- a/spec/ad-engine/utils/dimensions.spec.ts
+++ b/spec/ad-engine/utils/dimensions.spec.ts
@@ -5,13 +5,9 @@ import { getTopOffset } from '../../../src/ad-engine/utils';
 function getMockElement(top: number, left = 0, hidden = false): HTMLElement {
 	return {
 		classList: {
-			add: () => {
-				// noop for tests
-			},
+			add: () => {},
 			contains: () => hidden,
-			remove: () => {
-				// noop for tests
-			},
+			remove: () => {},
 		},
 		style: {},
 		getBoundingClientRect: () => ({

--- a/spec/ad-engine/utils/targeting.spec.ts
+++ b/spec/ad-engine/utils/targeting.spec.ts
@@ -72,15 +72,4 @@ describe('targeting', () => {
 			}),
 		).to.deep.equal([]);
 	});
-
-	it('getTargetingBundles returns empty array for wrong entry data', () => {
-		expect(
-			targeting.getTargetingBundles({
-				bundle1: {
-					s1: '_project43',
-					esrb: 'true',
-				},
-			}),
-		).to.deep.equal([]);
-	});
 });

--- a/spec/ad-engine/utils/try-property.spec.ts
+++ b/spec/ad-engine/utils/try-property.spec.ts
@@ -10,9 +10,7 @@ describe('tryProperty', () => {
 	});
 
 	it('should return a function if the property is found', async () => {
-		const testObject = { a: () => {
-			// noop for tests
-		} };
+		const testObject = { a: () => {} };
 		expect(typeof tryProperty(testObject, testProperties) === 'function').to.be.true;
 	});
 
@@ -22,9 +20,7 @@ describe('tryProperty', () => {
 	});
 
 	it('should return undefined if property is found', async () => {
-		const testObject = { d: () => {
-			// noop for tests
-		} };
+		const testObject = { d: () => {} };
 		expect(tryProperty(testObject, testProperties)).to.be.undefined;
 	});
 });
@@ -36,9 +32,7 @@ describe('whichProperty', () => {
 	});
 
 	it('should return found property name', async () => {
-		const testObject = { a: () => {
-			// noop for tests
-		} };
+		const testObject = { a: () => {} };
 		expect(whichProperty(testObject, testProperties)).to.be.equal('a');
 	});
 });

--- a/spec/ad-products/templates/uap/resolved-state.spec.ts
+++ b/spec/ad-products/templates/uap/resolved-state.spec.ts
@@ -44,12 +44,10 @@ const stubs = {
 				resolvedStateAspectRatio: 456,
 				image1: {
 					element: {
-						addEventListener: () => {
-							// noop for tests
-						},
-						src: 'test/image.jpg'
-					}
-				}
+						addEventListener: () => {},
+						src: 'test/image.jpg',
+					},
+				},
 			};
 		},
 		isResolvedState(): boolean {

--- a/spec/ad-products/video/porvata4/native-fullscreen.spec.ts
+++ b/spec/ad-products/video/porvata4/native-fullscreen.spec.ts
@@ -12,15 +12,9 @@ describe('native-fullscreen', () => {
 
 	it('should be supported if the video is valid', () => {
 		const testVideoMock = {
-			webkitRequestFullscreen: () => {
-				// noop for tests
-			},
-			webkitExitFullscreen: () => {
-				// noop for tests
-			},
-			onwebkitfullscreenchange: () => {
-				// noop for tests
-			},
+			webkitRequestFullscreen: () => {},
+			webkitExitFullscreen: () => {},
+			onwebkitfullscreenchange: () => {},
 		} as any;
 		const testInstance = new NativeFullscreen(testVideoMock);
 

--- a/spec/ad-products/video/porvata4/plugins/ias/ias-video-tracker.spec.ts
+++ b/spec/ad-products/video/porvata4/plugins/ias/ias-video-tracker.spec.ts
@@ -18,22 +18,16 @@ describe('IAS video tracker', () => {
 
 	function createPlayer(): PorvataPlayer {
 		return {
-			getAdsManager: () => {
-				// noop for tests
-			},
+			getAdsManager: () => {},
 			dom: {
-				getVideoContainer: () => {
-					// noop for tests
-				},
+				getVideoContainer: () => {},
 			},
 		} as PorvataPlayer;
 	}
 
 	beforeEach(() => {
 		window.googleImaVansAdapter = {
-			init: () => {
-				// noop for tests
-			},
+			init: () => {},
 		};
 
 		sandbox.stub(window.googleImaVansAdapter, 'init');

--- a/spec/platforms/shared/utils/collapsed-messages/message-box-service.spec.ts
+++ b/spec/platforms/shared/utils/collapsed-messages/message-box-service.spec.ts
@@ -7,13 +7,9 @@ describe('Message Box Service', () => {
 	function getMockElement(containsClass = false): HTMLElement {
 		return {
 			classList: {
-				add: () => {
-					// noop for tests
-				},
+				add: () => {},
 				contains: () => containsClass,
-				remove: () => {
-					// noop for tests
-				},
+				remove: () => {},
 			},
 		} as any;
 	}

--- a/spec/platforms/shared/utils/placeholder-service-helper.spec.ts
+++ b/spec/platforms/shared/utils/placeholder-service-helper.spec.ts
@@ -6,13 +6,9 @@ describe('placeholder service helper', () => {
 	function getMockElement(containsClass = false): HTMLElement {
 		return {
 			classList: {
-				add: () => {
-					// noop for tests
-				},
+				add: () => {},
 				contains: () => containsClass,
-				remove: () => {
-					// noop for tests
-				},
+				remove: () => {},
 			},
 		} as any;
 	}
@@ -28,18 +24,18 @@ describe('placeholder service helper', () => {
 			const actionEventMock = 'slotRendered';
 			const actionPayloadMock = 'forced_success';
 
-			expect(
-				placeholderHelper.shouldKeepPlaceholder(actionEventMock, actionPayloadMock),
-			).to.equal(true);
+			expect(placeholderHelper.shouldKeepPlaceholder(actionEventMock, actionPayloadMock)).to.equal(
+				true,
+			);
 		});
 
 		it('shouldDisplayPlaceholder returns false for rendered successfully slot', () => {
 			const actionEventMock = 'slotRendered';
 			const actionPayloadMock = 'success';
 
-			expect(
-				placeholderHelper.shouldKeepPlaceholder(actionEventMock, actionPayloadMock),
-			).to.equal(false);
+			expect(placeholderHelper.shouldKeepPlaceholder(actionEventMock, actionPayloadMock)).to.equal(
+				false,
+			);
 		});
 
 		it('shouldHidePlaceholder returns true when placeholder does not contain the right class', () => {

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,17 +1,3 @@
 {
-	"extends": ["../.eslintrc.json"],
-	"rules": {
-		"no-restricted-imports": [
-			"error",
-			{
-				"paths": [
-					"@ad-engine/core",
-					"@ad-engine/services",
-					"@ad-engine/tracking",
-					"@ad-engine/communication",
-					"@ad-engine/models"
-				]
-			}
-		]
-	}
+	"extends": ["../.eslintrc.json"]
 }

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+	"extends": ["../.eslintrc.json"],
+	"rules": {
+		"no-restricted-imports": [
+			"error",
+			{
+				"paths": [
+					"@ad-engine/core",
+					"@ad-engine/services",
+					"@ad-engine/tracking",
+					"@ad-engine/communication",
+					"@ad-engine/models"
+				]
+			}
+		]
+	}
+}

--- a/src/ad-bidders/.eslintrc.json
+++ b/src/ad-bidders/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["../../.eslintrc.json"],
+	"rules": {
+		"no-restricted-imports": [
+			"error",
+			{ "paths": ["/ad-bidders", "/ad-products", "/ad-services", "@ad-engine/services"] }
+		]
+	}
+}

--- a/src/ad-bidders/.eslintrc.json
+++ b/src/ad-bidders/.eslintrc.json
@@ -3,7 +3,10 @@
 	"rules": {
 		"no-restricted-imports": [
 			"error",
-			{ "paths": ["/ad-bidders", "/ad-products", "/ad-services", "@ad-engine/services"] }
+			{
+				"paths": ["@ad-engine/services"],
+				"patterns": ["**/ad-bidders/**", "**/ad-products/**", "**/ad-services/**"]
+			}
 		]
 	}
 }

--- a/src/ad-engine/.eslintrc.json
+++ b/src/ad-engine/.eslintrc.json
@@ -4,13 +4,12 @@
 		"no-restricted-imports": [
 			"error",
 			{
-				"paths": [
-					"/ad-bidders",
-					"/ad-engine",
-					"@ad-engine/core",
-					"@ad-engine/services",
-					"/ad-products",
-					"/ad-services"
+				"paths": ["@ad-engine/core", "@ad-engine/services"],
+				"patterns": [
+					"**/ad-bidders/**",
+					"**/ad-engine/**",
+					"**/ad-products/**",
+					"**/ad-services/**"
 				]
 			}
 		]

--- a/src/ad-engine/.eslintrc.json
+++ b/src/ad-engine/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../.eslintrc.json"],
+	"rules": {
+		"no-restricted-imports": [
+			"error",
+			{
+				"paths": [
+					"/ad-bidders",
+					"/ad-engine",
+					"@ad-engine/core",
+					"@ad-engine/services",
+					"/ad-products",
+					"/ad-services"
+				]
+			}
+		]
+	}
+}

--- a/src/ad-engine/services/local-cache.ts
+++ b/src/ad-engine/services/local-cache.ts
@@ -1,6 +1,5 @@
-import { Dictionary } from '@ad-engine/core';
-
 import { UniversalStorage } from './universal-storage';
+import { Dictionary } from '../models';
 
 interface CacheItem<T = any> {
 	expires?: number;

--- a/src/ad-engine/services/session-cookie.ts
+++ b/src/ad-engine/services/session-cookie.ts
@@ -1,5 +1,5 @@
 import * as Cookies from 'js-cookie';
-import { Dictionary } from '@ad-engine/core';
+import { Dictionary } from '../models';
 
 import { context } from './context-service';
 import { CookieStorageAdapter } from './cookie-storage-adapter';

--- a/src/ad-engine/utils/targeting.ts
+++ b/src/ad-engine/utils/targeting.ts
@@ -44,7 +44,7 @@ class Targeting {
 		return [];
 	}
 
-	private matchesTargetingBundle(bundle: Dictionary<string | string[]>): boolean {
+	private matchesTargetingBundle(bundle: Dictionary<string[]>): boolean {
 		return !Object.keys(bundle).some((key) => {
 			const acceptedValues = context.get(`targeting.${key}`);
 

--- a/src/ad-engine/utils/targeting.ts
+++ b/src/ad-engine/utils/targeting.ts
@@ -26,7 +26,7 @@ class Targeting {
 		return `_${wikiDbName || 'wikia'}`.replace('/[^0-9A-Z_a-z]/', '_');
 	}
 
-	getTargetingBundles(bundles: Dictionary<Dictionary<string | string[]>>): string | string[] {
+	getTargetingBundles(bundles: Dictionary<Dictionary<string[]>>): string | string[] {
 		try {
 			const selectedBundles = [];
 

--- a/src/ad-products/.eslintrc.json
+++ b/src/ad-products/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+	"extends": ["../../.eslintrc.json"],
+	"rules": {
+		"no-restricted-imports": [
+			"error",
+			{
+				"paths": ["/ad-bidders", "/ad-products", "/ad-services", "@ad-engine/services"]
+			}
+		]
+	}
+}

--- a/src/ad-products/.eslintrc.json
+++ b/src/ad-products/.eslintrc.json
@@ -4,7 +4,8 @@
 		"no-restricted-imports": [
 			"error",
 			{
-				"paths": ["/ad-bidders", "/ad-products", "/ad-services", "@ad-engine/services"]
+				"paths": ["@ad-engine/services"],
+				"patterns": ["**/ad-bidders/**", "**/ad-products/**", "**/ad-services/**"]
 			}
 		]
 	}

--- a/src/ad-services/.eslintrc.json
+++ b/src/ad-services/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+	"extends": ["../.eslintrc.json"],
+	"rules": {
+		"no-restricted-imports": [
+			"error",
+			{
+				"paths": ["/ad-bidders", "/ad-products", "/ad-services", "@ad-engine/services"]
+			}
+		]
+	}
+}

--- a/src/ad-services/.eslintrc.json
+++ b/src/ad-services/.eslintrc.json
@@ -4,7 +4,8 @@
 		"no-restricted-imports": [
 			"error",
 			{
-				"paths": ["/ad-bidders", "/ad-products", "/ad-services", "@ad-engine/services"]
+				"paths": ["@ad-engine/services"],
+				"patterns": ["**/ad-bidders/**", "**/ad-products/**", "**/ad-services/**"]
 			}
 		]
 	}

--- a/src/ad-services/ias-publisher-optimization/index.ts
+++ b/src/ad-services/ias-publisher-optimization/index.ts
@@ -85,7 +85,6 @@ class IasPublisherOptimization {
 			iasPETSlots.push(config);
 		});
 
-		// @ts-ignore the __iasPET API is not under our control
 		window.__iasPET = window.__iasPET || {};
 		window.__iasPET.queue = window.__iasPET.queue || [];
 		window.__iasPET.pubId = context.get('services.iasPublisherOptimization.pubId');

--- a/src/ad-tracking/.eslintrc.json
+++ b/src/ad-tracking/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../.eslintrc.json"],
+	"rules": {
+		"no-restricted-imports": [
+			"error",
+			{
+				"paths": [
+					"/ad-bidders",
+					"/ad-products",
+					"/ad-services",
+					"@ad-engine/services",
+					"/ad-tracking",
+					"@ad-engine/tracking"
+				]
+			}
+		]
+	}
+}

--- a/src/ad-tracking/.eslintrc.json
+++ b/src/ad-tracking/.eslintrc.json
@@ -4,13 +4,12 @@
 		"no-restricted-imports": [
 			"error",
 			{
-				"paths": [
-					"/ad-bidders",
-					"/ad-products",
-					"/ad-services",
-					"@ad-engine/services",
-					"/ad-tracking",
-					"@ad-engine/tracking"
+				"paths": ["@ad-engine/services", "@ad-engine/tracking"],
+				"patterns": [
+					"**/ad-bidders/**",
+					"**/ad-products/**",
+					"**/ad-services/**",
+					"**/ad-tracking/**"
 				]
 			}
 		]

--- a/src/platforms-shared/.eslintrc.json
+++ b/src/platforms-shared/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["../.eslintrc.json"],
+	"rules": {
+		"no-restricted-imports": [
+			"error",
+			{ "paths": ["/ad-bidders", "/ad-products", "/ad-services", "/ad-tracking"] }
+		]
+	}
+}

--- a/src/platforms-shared/.eslintrc.json
+++ b/src/platforms-shared/.eslintrc.json
@@ -3,7 +3,14 @@
 	"rules": {
 		"no-restricted-imports": [
 			"error",
-			{ "paths": ["/ad-bidders", "/ad-products", "/ad-services", "/ad-tracking"] }
+			{
+				"patterns": [
+					"**/ad-bidders/**",
+					"**/ad-products/**",
+					"**/ad-services/**",
+					"**/ad-tracking/**"
+				]
+			}
 		]
 	}
 }


### PR DESCRIPTION
Basically it's bringing back the blacklisted imports removed with `tslint` in this commit: https://github.com/Wikia/ad-engine/pull/1223/commits/f12ca36114605d5383b5622e14a28011322c93a5