### PR TITLE
remove ts-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1356,12 +1356,6 @@
 				}
 			}
 		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
-		},
 		"argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5995,12 +5989,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
-		},
 		"make-fetch-happen": {
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
@@ -9176,27 +9164,6 @@
 			"resolved": "https://registry.npmjs.org/ts-action-operators/-/ts-action-operators-9.1.2.tgz",
 			"integrity": "sha512-DZ+sJvBdOluThwCBcCdDnz0NiVeQxEwveL+cmkJGLO1ps+x/D0xwSefmOIa1S7p2nXFHH52ZPr/8VEvxZHaNgg=="
 		},
-		"ts-node": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
-			"integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
-			"dev": true,
-			"requires": {
-				"arg": "^4.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"source-map-support": "^0.5.6",
-				"yn": "^3.0.0"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-					"dev": true
-				}
-			}
-		},
 		"tsconfig-paths": {
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.8.0.tgz",
@@ -10287,12 +10254,6 @@
 					"dev": true
 				}
 			}
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
 		"sass-loader": "12.6.0",
 		"sinon": "4.1.4",
 		"string-replace-loader": "3.1.0",
-		"ts-node": "8.3.0",
 		"tsconfig-paths": "3.8.0",
 		"tslib": "1.10.0",
 		"typescript": "3.8.3",


### PR DESCRIPTION
`ts-node` was added in [ADEN-8364](https://fandom.atlassian.net/browse/ADEN-8364) as part of WDIO tests, which are now in a separate repo, so we don't need it anymore.