### PR TITLE
ADEN-12174 Remove an instant-config variable we do not need anymore

### DIFF
--- a/platforms/shared/setup/base-context.setup.ts
+++ b/platforms/shared/setup/base-context.setup.ts
@@ -94,7 +94,6 @@ export class BaseContextSetup implements DiProcess {
 			this.instantConfig.get('icFeaturedVideoPostroll'),
 		);
 
-		context.set('options.floorAdhesionAfterFV', this.instantConfig.get('icFloorAdhesionAfterFV'));
 		context.set(
 			'options.floorAdhesionNumberOfViewportsFromTopToPush',
 			this.instantConfig.get('icFloorAdhesionViewportsToStart'),

--- a/platforms/shared/slots/slots-context.ts
+++ b/platforms/shared/slots/slots-context.ts
@@ -24,7 +24,7 @@ export interface SlotsContextInterface {
 class SlotsContext implements SlotsContextInterface {
 	addSlotSize(slotName: string, size: [number, number]): void {
 		if (!context.get(`slots.${slotName}`)) {
-			throw new Error('Requested ad slot is not defined in the ad context');
+			throw new Error(`Requested ad slot is not defined in the ad context (${slotName})`);
 		}
 
 		context.push(`slots.${slotName}.defaultSizes`, size);

--- a/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-dynamic-slots.setup.ts
+++ b/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-dynamic-slots.setup.ts
@@ -69,14 +69,7 @@ export class UcpMobileDynamicSlotsSetup implements DiProcess {
 		]);
 
 		if (context.get('custom.hasFeaturedVideo')) {
-			if (context.get('options.floorAdhesionAfterFV')) {
-				this.waitForFloorAdhesionInjection();
-			} else {
-				communicationService.on(
-					eventsRepository.AD_ENGINE_UAP_NTC_LOADED,
-					this.waitForFloorAdhesionInjection.bind(this),
-				);
-			}
+			this.waitForFloorAdhesionInjection();
 		} else {
 			insertSlots([this.slotsDefinitionRepository.getFloorAdhesionConfig()]);
 		}

--- a/spec/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-dynamic-slots.setup.spec.ts
+++ b/spec/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-dynamic-slots.setup.spec.ts
@@ -1,0 +1,63 @@
+import sinon, { assert } from 'sinon';
+import { context, DomListener } from '@wikia/ad-engine';
+import { UcpMobileDynamicSlotsSetup } from '../../../../../platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-dynamic-slots.setup';
+import { UcpMobileSlotsDefinitionRepository } from '../../../../../platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-slots-definition-repository';
+import {
+	NativoSlotsDefinitionRepository,
+	QuizSlotsDefinitionRepository,
+} from '../../../../../platforms/shared';
+
+describe('floor_adhesion on ucp-mobile', () => {
+	const sandbox = sinon.createSandbox();
+	const instantConfig = {
+		get: () => [],
+	} as any;
+
+	const slotDefinitionRepositoryMock = new UcpMobileSlotsDefinitionRepository(instantConfig);
+	const nativoDefinitionRepositoryMock = new NativoSlotsDefinitionRepository(new DomListener());
+	const quizDefinitionRepositoryMock = new QuizSlotsDefinitionRepository();
+
+	beforeEach(() => {
+		sandbox.restore();
+		context.set('slots.mobile_prefooter', {});
+	});
+
+	after(() => {
+		context.remove('custom.hasFeaturedVideo');
+		context.remove('slots.mobile_prefooter');
+	});
+
+	it('is inserted right away on page load when there is no featured video on page', () => {
+		context.set('custom.hasFeaturedVideo', false);
+
+		const getFloorAdhesionConfigSpy = sandbox.spy(
+			slotDefinitionRepositoryMock,
+			'getFloorAdhesionConfig',
+		);
+		prepareAndExecuteDynamicSlotSetup();
+
+		assert.calledOnce(getFloorAdhesionConfigSpy);
+	});
+
+	it('is inserted after a slot injection when there is a feature video on page', () => {
+		context.set('custom.hasFeaturedVideo', true);
+
+		const getFloorAdhesionConfigSpy = sandbox.spy(
+			slotDefinitionRepositoryMock,
+			'getFloorAdhesionConfig',
+		);
+		prepareAndExecuteDynamicSlotSetup();
+
+		assert.notCalled(getFloorAdhesionConfigSpy);
+	});
+
+	function prepareAndExecuteDynamicSlotSetup() {
+		const dynamicSlotSetup = new UcpMobileDynamicSlotsSetup(
+			slotDefinitionRepositoryMock,
+			nativoDefinitionRepositoryMock,
+			quizDefinitionRepositoryMock,
+		);
+
+		dynamicSlotSetup.execute();
+	}
+});


### PR DESCRIPTION
We've enabled globally a new behaviour of `floor_adhesion` slot on featured video pages on Friday, 9/9. The numbers are looking good, so we can remove the variable from the instant-config service and its usages in the AdEngine.