### PR TITLE
ADEN-12209 Change the video ads logic

### DIFF
--- a/platforms/shared/setup/base-context.setup.ts
+++ b/platforms/shared/setup/base-context.setup.ts
@@ -93,6 +93,10 @@ export class BaseContextSetup implements DiProcess {
 			'options.video.isPostrollEnabled',
 			this.instantConfig.get('icFeaturedVideoPostroll'),
 		);
+		context.set(
+			'options.video.forceVideoAdsOnAllVideosExceptSecond',
+			this.instantConfig.get('icFeaturedVideoForceVideoAdsEverywhereExcept2ndVideo'),
+		);
 
 		context.set(
 			'options.floorAdhesionNumberOfViewportsFromTopToPush',

--- a/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
+++ b/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
@@ -4,6 +4,11 @@ import { createSandbox } from 'sinon';
 import { context } from '@wikia/ad-engine';
 import { JWPlayerHelper } from '@wikia/ad-products/video/jwplayer/helpers/jwplayer-helper';
 
+type shouldPrerollAppear = boolean;
+type shouldMidrollAppear = boolean;
+type shouldPostrollAppear = boolean;
+type videoTestRow = [shouldPrerollAppear, shouldMidrollAppear, shouldPostrollAppear];
+
 describe('JWPlayer helper', () => {
 	const sandbox = createSandbox();
 	let adSlotStub, helper;
@@ -58,7 +63,7 @@ describe('JWPlayer helper', () => {
 			]);
 		});
 
-		function simulatePlaysAndVerifyResults(testData): void {
+		function simulatePlaysAndVerifyResults(testData: videoTestRow[]): void {
 			testData.forEach((expectedResults, videoPlayIndex) => {
 				const videoNumber = videoPlayIndex + 1;
 				expect(helper.shouldPlayPreroll(videoNumber)).to.equal(expectedResults[0]);

--- a/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
+++ b/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
@@ -24,6 +24,7 @@ describe('JWPlayer helper', () => {
 			context.set('options.video.playAdsOnNextVideo', true);
 			context.set('options.video.isMidrollEnabled', false);
 			context.set('options.video.isPostrollEnabled', false);
+			context.set('options.video.forceVideoAdsOnAllVideosExceptSecond', true);
 		});
 
 		afterEach(() => {
@@ -32,6 +33,7 @@ describe('JWPlayer helper', () => {
 			context.remove('options.video.playAdsOnNextVideo');
 			context.remove('options.video.isMidrollEnabled');
 			context.remove('options.video.isPostrollEnabled');
+			context.remove('options.video.forceVideoAdsOnAllVideosExceptSecond');
 		});
 
 		it('works correctly for the default settings - no ad for the 2nd video, no midroll, no postroll', () => {

--- a/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
+++ b/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import { context } from '@wikia/ad-engine';
+import { JWPlayerHelper } from '@wikia/ad-products/video/jwplayer/helpers/jwplayer-helper';
+
+describe('JWPlayer helper', () => {
+	const sandbox = createSandbox();
+	let adSlotStub;
+
+	describe('shouldPlayPreroll()', () => {
+		beforeEach(() => {
+			adSlotStub = {
+				isEnabled: sandbox.stub().returns(true),
+			};
+
+			context.set('options.video.adsOnNextVideoFrequency', 3);
+			context.set('options.video.playAdsOnNextVideo', true);
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+
+			context.remove('options.video.adsOnNextVideoFrequency');
+			context.remove('options.video.playAdsOnNextVideo');
+		});
+
+		it('returns true when it is the first video', () => {
+			const helper = new JWPlayerHelper(adSlotStub, null, null);
+			expect(helper.shouldPlayPreroll(1)).to.be.true;
+		});
+
+		it('returns false when it is the second video', () => {
+			const helper = new JWPlayerHelper(adSlotStub, null, null);
+			expect(helper.shouldPlayPreroll(2)).to.be.false;
+		});
+
+		it('returns false when it is the third video', () => {
+			const helper = new JWPlayerHelper(adSlotStub, null, null);
+			expect(helper.shouldPlayPreroll(3)).to.be.false;
+		});
+
+		it('returns false when it is the fourth video', () => {
+			const helper = new JWPlayerHelper(adSlotStub, null, null);
+			expect(helper.shouldPlayPreroll(4)).to.be.true;
+		});
+	});
+});

--- a/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
+++ b/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
@@ -6,43 +6,74 @@ import { JWPlayerHelper } from '@wikia/ad-products/video/jwplayer/helpers/jwplay
 
 describe('JWPlayer helper', () => {
 	const sandbox = createSandbox();
-	let adSlotStub;
+	let adSlotStub, helper;
 
-	describe('shouldPlayPreroll()', () => {
+	describe('should play pre-, mid- and post-rolls depending on the settings', () => {
 		beforeEach(() => {
 			adSlotStub = {
 				isEnabled: sandbox.stub().returns(true),
 			};
 
-			context.set('options.video.adsOnNextVideoFrequency', 3);
+			helper = new JWPlayerHelper(adSlotStub, null, null);
+
 			context.set('options.video.playAdsOnNextVideo', true);
+			context.set('options.video.isMidrollEnabled', false);
+			context.set('options.video.isPostrollEnabled', false);
 		});
 
 		afterEach(() => {
 			sandbox.restore();
 
-			context.remove('options.video.adsOnNextVideoFrequency');
 			context.remove('options.video.playAdsOnNextVideo');
+			context.remove('options.video.isMidrollEnabled');
+			context.remove('options.video.isPostrollEnabled');
 		});
 
-		it('returns true when it is the first video', () => {
-			const helper = new JWPlayerHelper(adSlotStub, null, null);
+		it('works correctly for the default settings - no ad for the 2nd video, no midroll, no postroll', () => {
 			expect(helper.shouldPlayPreroll(1)).to.be.true;
-		});
+			expect(helper.shouldPlayMidroll(1)).to.be.false;
+			expect(helper.shouldPlayPostroll(1)).to.be.false;
 
-		it('returns false when it is the second video', () => {
-			const helper = new JWPlayerHelper(adSlotStub, null, null);
 			expect(helper.shouldPlayPreroll(2)).to.be.false;
+			expect(helper.shouldPlayMidroll(2)).to.be.false;
+			expect(helper.shouldPlayPostroll(2)).to.be.false;
+
+			expect(helper.shouldPlayPreroll(3)).to.be.true;
+			expect(helper.shouldPlayMidroll(3)).to.be.false;
+			expect(helper.shouldPlayPostroll(3)).to.be.false;
 		});
 
-		it('returns false when it is the third video', () => {
-			const helper = new JWPlayerHelper(adSlotStub, null, null);
+		it('works correctly when mid- and post-rolls are enabled - no ad for the 2nd video', () => {
+			context.set('options.video.isMidrollEnabled', true);
+			context.set('options.video.isPostrollEnabled', true);
+
+			expect(helper.shouldPlayPreroll(1)).to.be.true;
+			expect(helper.shouldPlayMidroll(1)).to.be.true;
+			expect(helper.shouldPlayPostroll(1)).to.be.true;
+
+			expect(helper.shouldPlayPreroll(2)).to.be.false;
+			expect(helper.shouldPlayMidroll(2)).to.be.false;
+			expect(helper.shouldPlayPostroll(2)).to.be.false;
+
+			expect(helper.shouldPlayPreroll(3)).to.be.true;
+			expect(helper.shouldPlayMidroll(3)).to.be.true;
+			expect(helper.shouldPlayPostroll(3)).to.be.true;
+		});
+
+		it('works correctly when the ads for next videos are disabled - only one preroll', () => {
+			context.set('options.video.playAdsOnNextVideo', false);
+
+			expect(helper.shouldPlayPreroll(1)).to.be.true;
+			expect(helper.shouldPlayMidroll(1)).to.be.false;
+			expect(helper.shouldPlayPostroll(1)).to.be.false;
+
+			expect(helper.shouldPlayPreroll(2)).to.be.false;
+			expect(helper.shouldPlayMidroll(2)).to.be.false;
+			expect(helper.shouldPlayPostroll(2)).to.be.false;
+
 			expect(helper.shouldPlayPreroll(3)).to.be.false;
-		});
-
-		it('returns false when it is the fourth video', () => {
-			const helper = new JWPlayerHelper(adSlotStub, null, null);
-			expect(helper.shouldPlayPreroll(4)).to.be.true;
+			expect(helper.shouldPlayMidroll(3)).to.be.false;
+			expect(helper.shouldPlayPostroll(3)).to.be.false;
 		});
 	});
 });

--- a/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
+++ b/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
@@ -30,50 +30,41 @@ describe('JWPlayer helper', () => {
 		});
 
 		it('works correctly for the default settings - no ad for the 2nd video, no midroll, no postroll', () => {
-			expect(helper.shouldPlayPreroll(1)).to.be.true;
-			expect(helper.shouldPlayMidroll(1)).to.be.false;
-			expect(helper.shouldPlayPostroll(1)).to.be.false;
-
-			expect(helper.shouldPlayPreroll(2)).to.be.false;
-			expect(helper.shouldPlayMidroll(2)).to.be.false;
-			expect(helper.shouldPlayPostroll(2)).to.be.false;
-
-			expect(helper.shouldPlayPreroll(3)).to.be.true;
-			expect(helper.shouldPlayMidroll(3)).to.be.false;
-			expect(helper.shouldPlayPostroll(3)).to.be.false;
+			simulatePlaysAndVerifyResults([
+				[true, false, false],
+				[false, false, false],
+				[true, false, false],
+			]);
 		});
 
 		it('works correctly when mid- and post-rolls are enabled - no ad for the 2nd video', () => {
 			context.set('options.video.isMidrollEnabled', true);
 			context.set('options.video.isPostrollEnabled', true);
 
-			expect(helper.shouldPlayPreroll(1)).to.be.true;
-			expect(helper.shouldPlayMidroll(1)).to.be.true;
-			expect(helper.shouldPlayPostroll(1)).to.be.true;
-
-			expect(helper.shouldPlayPreroll(2)).to.be.false;
-			expect(helper.shouldPlayMidroll(2)).to.be.false;
-			expect(helper.shouldPlayPostroll(2)).to.be.false;
-
-			expect(helper.shouldPlayPreroll(3)).to.be.true;
-			expect(helper.shouldPlayMidroll(3)).to.be.true;
-			expect(helper.shouldPlayPostroll(3)).to.be.true;
+			simulatePlaysAndVerifyResults([
+				[true, true, true],
+				[false, false, false],
+				[true, true, true],
+			]);
 		});
 
 		it('works correctly when the ads for next videos are disabled - only one preroll', () => {
 			context.set('options.video.playAdsOnNextVideo', false);
 
-			expect(helper.shouldPlayPreroll(1)).to.be.true;
-			expect(helper.shouldPlayMidroll(1)).to.be.false;
-			expect(helper.shouldPlayPostroll(1)).to.be.false;
-
-			expect(helper.shouldPlayPreroll(2)).to.be.false;
-			expect(helper.shouldPlayMidroll(2)).to.be.false;
-			expect(helper.shouldPlayPostroll(2)).to.be.false;
-
-			expect(helper.shouldPlayPreroll(3)).to.be.false;
-			expect(helper.shouldPlayMidroll(3)).to.be.false;
-			expect(helper.shouldPlayPostroll(3)).to.be.false;
+			simulatePlaysAndVerifyResults([
+				[true, false, false],
+				[false, false, false],
+				[false, false, false],
+			]);
 		});
+
+		function simulatePlaysAndVerifyResults(testData): void {
+			testData.forEach((expectedResults, videoPlayIndex) => {
+				const videoNumber = videoPlayIndex + 1;
+				expect(helper.shouldPlayPreroll(videoNumber)).to.equal(expectedResults[0]);
+				expect(helper.shouldPlayMidroll(videoNumber)).to.equal(expectedResults[1]);
+				expect(helper.shouldPlayPostroll(videoNumber)).to.equal(expectedResults[2]);
+			});
+		}
 	});
 });

--- a/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
+++ b/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
@@ -65,6 +65,20 @@ describe('JWPlayer helper', () => {
 			]);
 		});
 
+		it('works correctly for the capping logic - ads before 1st and 3rd video, no midroll, no postroll', () => {
+			context.set('options.video.forceVideoAdsOnAllVideosExceptSecond', false);
+			context.set('options.video.adsOnNextVideoFrequency', 3);
+			context.set('options.video.isMidrollEnabled', false);
+			context.set('options.video.isPostrollEnabled', false);
+
+			simulatePlaysAndVerifyResults([
+				[true, false, false],
+				[false, false, false],
+				[false, false, false],
+				[true, false, false],
+			]);
+		});
+
 		function simulatePlaysAndVerifyResults(testData: videoTestRow[]): void {
 			testData.forEach((expectedResults, videoPlayIndex) => {
 				const videoNumber = videoPlayIndex + 1;

--- a/spec/ad-products/video/jwplayer/streams/jwplayer-stream-state.spec.ts
+++ b/spec/ad-products/video/jwplayer/streams/jwplayer-stream-state.spec.ts
@@ -58,48 +58,78 @@ describe('Jwplayer Stream State', () => {
 			expect(uniq(results.map((value) => value.correlator)).length).to.equal(3);
 		});
 
-		it('should increase rv for every preroll in the same slot except 1st and 2nd', () => {
+		it('should increase rv after every preroll in the same slot except 1st and 2nd', () => {
 			context.set('options.video.forceVideoAdsOnAllVideosExceptSecond', true);
 
 			// init
 			subject$.next({ name: 'adRequest', payload: { tag: 'tag' } });
-			expect(results[0].rv).to.equal(1);
+			expect(results[0].rv).to.equal(1, 'rv in the initial adRequest is incorrect');
 
 			// first video and preroll
 			subject$.next({ name: 'beforePlay', payload: undefined });
 			subject$.next({ name: 'adStarted', payload: undefined });
-			expect(results[3].rv).to.equal(1);
+			expect(results[3].rv).to.equal(1, 'rv for preroll before 1st video is incorrect');
 
 			// midroll
 			subject$.next({ name: 'videoMidPoint', payload: undefined });
 			subject$.next({ name: 'adStarted', payload: undefined });
-			expect(results[6].rv).to.equal(1);
+			expect(results[6].rv).to.equal(1, 'rv for midroll in 1st video is incorrect');
 
 			// postroll
 			subject$.next({ name: 'beforeComplete', payload: undefined });
 			subject$.next({ name: 'adStarted', payload: undefined });
-			expect(results[9].rv).to.equal(1);
+			expect(results[9].rv).to.equal(1, 'rv for postroll after 1st video is incorrect');
 
 			subject$.next({ name: 'complete', payload: undefined });
 
 			// second video and preroll
 			subject$.next({ name: 'beforePlay', payload: undefined });
 			subject$.next({ name: 'adStarted', payload: undefined });
-			expect(results[15].rv).to.equal(1);
+			expect(results[15].rv).to.equal(1, 'rv for preroll before 2nd video is incorrect');
+
+			// midroll
+			subject$.next({ name: 'videoMidPoint', payload: undefined });
+			subject$.next({ name: 'adStarted', payload: undefined });
+			expect(results[18].rv).to.equal(1, 'rv for midroll in 2nd video is incorrect');
+
+			// postroll
+			subject$.next({ name: 'beforeComplete', payload: undefined });
+			subject$.next({ name: 'adStarted', payload: undefined });
+			expect(results[21].rv).to.equal(1, 'rv for postroll after 2nd video is incorrect');
 
 			subject$.next({ name: 'complete', payload: undefined });
 
 			// third video and preroll
 			subject$.next({ name: 'beforePlay', payload: undefined });
 			subject$.next({ name: 'adStarted', payload: undefined });
-			expect(results[21].rv).to.equal(2);
+			expect(results[27].rv).to.equal(2, 'rv for preroll before 3rd video is incorrect');
+
+			// midroll
+			subject$.next({ name: 'videoMidPoint', payload: undefined });
+			subject$.next({ name: 'adStarted', payload: undefined });
+			expect(results[30].rv).to.equal(2, 'rv for midroll in 3rd video is incorrect');
+
+			// postroll
+			subject$.next({ name: 'beforeComplete', payload: undefined });
+			subject$.next({ name: 'adStarted', payload: undefined });
+			expect(results[33].rv).to.equal(2, 'rv for postroll after 3rd video is incorrect');
 
 			subject$.next({ name: 'complete', payload: undefined });
 
 			// fourth video and preroll
 			subject$.next({ name: 'beforePlay', payload: undefined });
 			subject$.next({ name: 'adStarted', payload: undefined });
-			expect(results[27].rv).to.equal(3);
+			expect(results[39].rv).to.equal(3, 'rv for preroll before 4th video is incorrect');
+
+			// midroll
+			subject$.next({ name: 'videoMidPoint', payload: undefined });
+			subject$.next({ name: 'adStarted', payload: undefined });
+			expect(results[42].rv).to.equal(3, 'rv for midroll in 4th video is incorrect');
+
+			// postroll
+			subject$.next({ name: 'beforeComplete', payload: undefined });
+			subject$.next({ name: 'adStarted', payload: undefined });
+			expect(results[45].rv).to.equal(3, 'rv for postroll after 4th video is incorrect');
 		});
 	});
 

--- a/src/ad-engine/listeners/listeners.ts
+++ b/src/ad-engine/listeners/listeners.ts
@@ -13,6 +13,7 @@ export interface VideoData {
 	position: string;
 	user_block_autoplay?: -1 | 0 | 1;
 	video_id?: string;
+	video_depth?: number | string;
 }
 
 export interface VideoEventData extends VideoData {

--- a/src/ad-engine/listeners/listeners.ts
+++ b/src/ad-engine/listeners/listeners.ts
@@ -13,7 +13,7 @@ export interface VideoData {
 	position: string;
 	user_block_autoplay?: -1 | 0 | 1;
 	video_id?: string;
-	video_depth?: number | string;
+	video_number?: number | string;
 }
 
 export interface VideoEventData extends VideoData {

--- a/src/ad-products/tracking/video/video-event-data-provider.ts
+++ b/src/ad-products/tracking/video/video-event-data-provider.ts
@@ -32,6 +32,7 @@ export class VideoEventDataProvider {
 			tz_offset: now.getTimezoneOffset(),
 			user_block_autoplay: videoData.user_block_autoplay,
 			video_id: videoData.video_id || '',
+			video_depth: videoData.video_depth || '',
 		};
 	}
 }

--- a/src/ad-products/tracking/video/video-event-data-provider.ts
+++ b/src/ad-products/tracking/video/video-event-data-provider.ts
@@ -32,7 +32,7 @@ export class VideoEventDataProvider {
 			tz_offset: now.getTimezoneOffset(),
 			user_block_autoplay: videoData.user_block_autoplay,
 			video_id: videoData.video_id || '',
-			video_depth: videoData.video_depth || '',
+			video_number: videoData.video_number || '',
 		};
 	}
 }

--- a/src/ad-products/video/jwplayer/handlers/jwplayer-tracking-handler.ts
+++ b/src/ad-products/video/jwplayer/handlers/jwplayer-tracking-handler.ts
@@ -83,7 +83,7 @@ export class JWPlayerTrackingHandler {
 			position: this.adSlot.config.slotName,
 			user_block_autoplay: this.getUserBlockAutoplay(),
 			video_id: event.state.playlistItem.mediaid || '',
-			video_depth: event.state.depth || '',
+			video_number: event.state.depth || '',
 		};
 	}
 

--- a/src/ad-products/video/jwplayer/handlers/jwplayer-tracking-handler.ts
+++ b/src/ad-products/video/jwplayer/handlers/jwplayer-tracking-handler.ts
@@ -83,6 +83,7 @@ export class JWPlayerTrackingHandler {
 			position: this.adSlot.config.slotName,
 			user_block_autoplay: this.getUserBlockAutoplay(),
 			video_id: event.state.playlistItem.mediaid || '',
+			video_depth: event.state.depth || '',
 		};
 	}
 

--- a/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
+++ b/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
@@ -120,11 +120,23 @@ export class JWPlayerHelper {
 
 	private shouldPlayAdOnNextVideo(videoPlaylistOrderNumber: number): boolean {
 		const SPONSORED_VIDEO_INDEX = 2;
-
-		return (
-			context.get('options.video.playAdsOnNextVideo') &&
-			videoPlaylistOrderNumber !== SPONSORED_VIDEO_INDEX
+		const capping = context.get('options.video.adsOnNextVideoFrequency');
+		const videoAdsOnAllVideosExceptSecond = context.get(
+			'options.video.forceVideoAdsOnAllVideosExceptSecond',
 		);
+
+		if (videoAdsOnAllVideosExceptSecond) {
+			return (
+				context.get('options.video.playAdsOnNextVideo') &&
+				videoPlaylistOrderNumber !== SPONSORED_VIDEO_INDEX
+			);
+		} else {
+			return (
+				context.get('options.video.playAdsOnNextVideo') &&
+				capping > 0 &&
+				(videoPlaylistOrderNumber - 1) % capping === 0
+			);
+		}
 	}
 
 	playVideoAd(position: 'midroll' | 'postroll' | 'preroll', state: JwpState): void {

--- a/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
+++ b/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
@@ -93,30 +93,38 @@ export class JWPlayerHelper {
 		this.adSlot.setConfigProperty('targeting.rv', state.rv);
 	}
 
-	shouldPlayPreroll(videoDepth: number): boolean {
-		return this.canAdBePlayed(videoDepth);
+	shouldPlayPreroll(videoPlaylistOrderNumber: number): boolean {
+		return this.canAdBePlayed(videoPlaylistOrderNumber);
 	}
 
-	shouldPlayMidroll(videoDepth: number): boolean {
-		return context.get('options.video.isMidrollEnabled') && this.canAdBePlayed(videoDepth);
-	}
-
-	shouldPlayPostroll(videoDepth: number): boolean {
-		return context.get('options.video.isPostrollEnabled') && this.canAdBePlayed(videoDepth);
-	}
-
-	private canAdBePlayed(depth: number): boolean {
-		const isReplay = depth > 1;
-
+	shouldPlayMidroll(videoPlaylistOrderNumber: number): boolean {
 		return (
-			this.adSlot.isEnabled() && (!isReplay || (isReplay && this.shouldPlayAdOnNextVideo(depth)))
+			context.get('options.video.isMidrollEnabled') && this.canAdBePlayed(videoPlaylistOrderNumber)
 		);
 	}
 
-	private shouldPlayAdOnNextVideo(depth: number): boolean {
+	shouldPlayPostroll(videoPlaylistOrderNumber: number): boolean {
+		return (
+			context.get('options.video.isPostrollEnabled') && this.canAdBePlayed(videoPlaylistOrderNumber)
+		);
+	}
+
+	private canAdBePlayed(videoPlaylistOrderNumber: number): boolean {
+		const isReplay = videoPlaylistOrderNumber > 1;
+
+		return (
+			this.adSlot.isEnabled() &&
+			(!isReplay || (isReplay && this.shouldPlayAdOnNextVideo(videoPlaylistOrderNumber)))
+		);
+	}
+
+	private shouldPlayAdOnNextVideo(videoPlaylistOrderNumber: number): boolean {
 		const SPONSORED_VIDEO_INDEX = 2;
 
-		return context.get('options.video.playAdsOnNextVideo') && depth !== SPONSORED_VIDEO_INDEX;
+		return (
+			context.get('options.video.playAdsOnNextVideo') &&
+			videoPlaylistOrderNumber !== SPONSORED_VIDEO_INDEX
+		);
 	}
 
 	playVideoAd(position: 'midroll' | 'postroll' | 'preroll', state: JwpState): void {

--- a/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
+++ b/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
@@ -140,6 +140,7 @@ export class JWPlayerHelper {
 			targeting: {
 				rv: state.rv,
 				v1: state.playlistItem.mediaid || '',
+				videoDepth: state.depth,
 				...this.targeting,
 			},
 		});

--- a/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
+++ b/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
@@ -114,11 +114,7 @@ export class JWPlayerHelper {
 	}
 
 	private shouldPlayAdOnNextVideo(depth: number): boolean {
-		const capping = context.get('options.video.adsOnNextVideoFrequency');
-
-		return (
-			context.get('options.video.playAdsOnNextVideo') && capping > 0 && (depth - 1) % capping === 0
-		);
+		return context.get('options.video.playAdsOnNextVideo') && depth !== 2;
 	}
 
 	playVideoAd(position: 'midroll' | 'postroll' | 'preroll', state: JwpState): void {

--- a/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
+++ b/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
@@ -142,7 +142,6 @@ export class JWPlayerHelper {
 			targeting: {
 				rv: state.rv,
 				v1: state.playlistItem.mediaid || '',
-				videoDepth: state.depth,
 				...this.targeting,
 			},
 		});

--- a/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
+++ b/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
@@ -114,7 +114,9 @@ export class JWPlayerHelper {
 	}
 
 	private shouldPlayAdOnNextVideo(depth: number): boolean {
-		return context.get('options.video.playAdsOnNextVideo') && depth !== 2;
+		const SPONSORED_VIDEO_INDEX = 2;
+
+		return context.get('options.video.playAdsOnNextVideo') && depth !== SPONSORED_VIDEO_INDEX;
 	}
 
 	playVideoAd(position: 'midroll' | 'postroll' | 'preroll', state: JwpState): void {

--- a/src/ad-products/video/jwplayer/streams/jwplayer-stream-state.ts
+++ b/src/ad-products/video/jwplayer/streams/jwplayer-stream-state.ts
@@ -105,7 +105,15 @@ function scanCorrelatorDepth<T>(): RxJsOperator<T, VideoDepth> {
 }
 
 function calculateRV(depth: number, capping: number): number {
-	return depth < 2 || !capping ? 1 : Math.floor((depth - 1) / capping) + 1;
+	const videoAdsOnAllVideosExceptSecond = context.get(
+		'options.video.forceVideoAdsOnAllVideosExceptSecond',
+	);
+
+	if (videoAdsOnAllVideosExceptSecond) {
+		return depth <= 2 ? 1 : depth - 1;
+	} else {
+		return depth < 2 || !capping ? 1 : Math.floor((depth - 1) / capping) + 1;
+	}
 }
 
 function createVastParams<T extends { payload: JWPlayerEvent }>(): RxJsOperator<T, VastParams> {


### PR DESCRIPTION
The code changes introduce more requests for video ads for 3rd, 4th and so on video plays. We block requesting ads for the 2nd video because it may be a sponsored one.