### PR TITLE
ADEN-12171 | case insensitive VIDEO_TIER_3 bundle recognition

### DIFF
--- a/spec/core/utils/targeting.spec.ts
+++ b/spec/core/utils/targeting.spec.ts
@@ -11,6 +11,11 @@ describe('targeting', () => {
 	});
 
 	afterEach(() => {
+		context.remove('targeting.bundles');
+		context.remove('targeting.esrb');
+		context.remove('targeting.s1');
+		context.remove('targeting.skin');
+
 		sandbox.restore();
 	});
 

--- a/spec/core/utils/targeting.spec.ts
+++ b/spec/core/utils/targeting.spec.ts
@@ -73,6 +73,35 @@ describe('targeting', () => {
 		).to.deep.equal([]);
 	});
 
+	it('getTargetingBundles will not add VIDEO_TIER_3_BUNDLE for tier 1 and 2', () => {
+		context.set('targeting.s1', '_project34');
+		context.set('targeting.skin', 'ucp_desktop');
+
+		expect(
+			targeting.getTargetingBundles({
+				VIDEO_TIER_1_AND_2_BUNDLE: {
+					s1: ['_project34'],
+				},
+			}),
+		).to.deep.equal(['VIDEO_TIER_1_AND_2_BUNDLE']);
+
+		expect(
+			targeting.getTargetingBundles({
+				video_tier_1_and_2_bundle: {
+					s1: ['_project34'],
+				},
+			}),
+		).to.deep.equal(['video_tier_1_and_2_bundle']);
+
+		expect(
+			targeting.getTargetingBundles({
+				VIDEO_tier_1_and_2_bundle: {
+					s1: ['_project34'],
+				},
+			}),
+		).to.deep.equal(['VIDEO_tier_1_and_2_bundle']);
+	});
+
 	it('getTargetingBundles returns backend, frontent and code bundles', () => {
 		context.set('targeting.bundles', ['backend_bundle']);
 		context.set('targeting.s1', '_harrypotter');

--- a/src/core/utils/targeting.ts
+++ b/src/core/utils/targeting.ts
@@ -64,7 +64,7 @@ class Targeting {
 
 		if (
 			context.get('targeting.skin').includes('ucp_') &&
-			!bundles.includes('VIDEO_TIER_1_AND_2_BUNDLE')
+			!bundles.some((bundle) => bundle.toUpperCase() === 'VIDEO_TIER_1_AND_2_BUNDLE')
 		) {
 			bundles.push('VIDEO_TIER_3_BUNDLE');
 		}


### PR DESCRIPTION
We will upload bundles as TAGS into tag manager and they are set up in lower case there, whereas in ICBM we use upper case ones. For GAM it does not matter