### PR TITLE
ADEN-12452 Improve 1st video preroll behaviour 

### DIFF
--- a/spec/ad-products/video/jwplayer/helpers/jwplayer-helper-skipping-sponsored-video.spec.ts
+++ b/spec/ad-products/video/jwplayer/helpers/jwplayer-helper-skipping-sponsored-video.spec.ts
@@ -102,7 +102,7 @@ describe('JwplayerHelperSkippingSponsoredVideo', () => {
 			]);
 		});
 
-		it('works correctly when there is no global window.sponsoredVideos', () => {
+		it('works correctly when there is no global window.sponsoredVideos', (done) => {
 			window.sponsoredVideos = undefined;
 			helper = new JwplayerHelperSkippingSponsoredVideo(
 				adSlotStub,
@@ -110,6 +110,7 @@ describe('JwplayerHelperSkippingSponsoredVideo', () => {
 				null,
 				window.sponsoredVideos,
 			);
+			done();
 
 			simulatePlaysAndVerifyResults([
 				[false, false, false],

--- a/src/ad-products/video/jwplayer/handlers/jwplayer-handler.ts
+++ b/src/ad-products/video/jwplayer/handlers/jwplayer-handler.ts
@@ -104,9 +104,6 @@ export class JWPlayerHandler {
 	private beforePlay(): Observable<unknown> {
 		return this.stream$.pipe(
 			ofJwpEvent('beforePlay'),
-			tap(async () => {
-				await this.helper.ensureAdditionalSettings();
-			}),
 			tap(({ state }) => this.helper.updateVideoProperties(state)),
 			filter(({ state }) =>
 				this.helper.shouldPlayPreroll(state.depth, state?.playlistItem?.mediaid),

--- a/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
+++ b/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
@@ -176,8 +176,4 @@ export class JWPlayerHelper {
 			},
 		});
 	}
-
-	ensureAdditionalSettings(): void {
-		return;
-	}
 }

--- a/src/core/utils/script-loader.ts
+++ b/src/core/utils/script-loader.ts
@@ -95,6 +95,26 @@ class ScriptLoader implements ScriptLoaderInterface {
 			request.send();
 		});
 	}
+
+	loadSync(url: string): string | boolean {
+		try {
+			const request = new XMLHttpRequest();
+			request.open('GET', url, false);
+			request.send(null);
+
+			if (request.status !== 200) {
+				return false;
+			}
+
+			if (request.responseText.length === 0) {
+				return false;
+			}
+
+			return request.responseText;
+		} catch (e) {
+			return false;
+		}
+	}
 }
 
 export const scriptLoader = new ScriptLoader();


### PR DESCRIPTION
Moving `sponsoredVideos` from global to class property and ensure its set earlier doesn't help minimise the errors logged to Kibana. This is a 2nd quick-fix that forces the fallback API call to be synchronous.