### PR TITLE
ADEN-12935 - Fixed problems with sending over_18 flag

### DIFF
--- a/@types/fandom/index.d.ts
+++ b/@types/fandom/index.d.ts
@@ -19,6 +19,7 @@ interface ITrackingParameters {
 	sessionId: string;
 	pvUID: string;
 	ppid?: string;
+	over_18?: string;
 }
 
 interface ISiteParameters {

--- a/src/ad-services/identity-setup/index.ts
+++ b/src/ad-services/identity-setup/index.ts
@@ -22,6 +22,14 @@ export class IdentitySetup extends BaseServiceSetup {
 			utils.logger(this.logGroup, 'initialized');
 			this.identityReady();
 		});
+
+		communicationService.on(eventsRepository.IDENTITY_PARTNER_DATA_OBTAINED, () => {
+			const over18 = window.fandomContext.tracking.over_18;
+
+			if (over18) {
+				targetingService.set('over_18', over18);
+			}
+		});
 		return identityPromise;
 	}
 }


### PR DESCRIPTION
In this PR I've fixed problems with sending over_18 flag. Before migrating PPID logic to Identity Storage, we were automatically setting over_18 in tracking object. After migration, we were setting this into window.fandomContext.tracking instead window.ads.adTargeting. I decided to add a new listener for communicationService instead adding a new value to window.ads.adTargeting, as we want to be able to work without AdEngine. It means, that we can not stick to ads.adTargeting object. Right now it will listen for an event sent when IE is ready and after receiving it, AdEngine will read value from fandomContext and move it to ads.adTargeting.