### PR TITLE
ADEN-12898 Extend current A9 initialization

### DIFF
--- a/spec/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.spec.ts
+++ b/spec/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.spec.ts
@@ -1,0 +1,161 @@
+import { Dictionary } from '@wikia/core';
+import { OpenRtb2ContentCategories, OpenRtb2Object } from '@wikia/platforms/shared';
+import {
+	FandomContext,
+	Page,
+	Site,
+} from '@wikia/platforms/shared/context/targeting/targeting-strategies/models/fandom-context';
+import { OpenRtb2Tags } from '@wikia/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags';
+import { expect } from 'chai';
+
+const pageId = 645;
+const pageName = 'test-page';
+const pageHostname = 'project43.preview.fandom.com';
+const pageLang = 'pl';
+const createExpectedOpenRtb2Object = (
+	cat: OpenRtb2ContentCategories[] = [],
+	tags: Dictionary<string[]> = {},
+	mobile: 0 | 1 = 0,
+): OpenRtb2Object => {
+	const keywords = [...new Set(Object.keys(tags).flatMap((key) => tags[key]))].sort().join(',');
+
+	return {
+		site: {
+			id: pageId.toString(),
+			name: pageName,
+			domain: pageHostname,
+			cat,
+			mobile,
+			content: {
+				language: pageLang,
+				context: 5,
+			},
+			keywords,
+		},
+		user: {},
+	};
+};
+const testCases: {
+	testName: string;
+	categories: string[];
+	tags: Dictionary<string[]>;
+	taxonomies: string[];
+	openRtb2ContentCategories: OpenRtb2ContentCategories[];
+}[] = [
+	{
+		testName: 'empty fandomContext',
+		categories: [],
+		tags: {},
+		taxonomies: [],
+		openRtb2ContentCategories: [],
+	},
+	{
+		testName: 'LotR wiki',
+		categories: ['ent', 'movies'],
+		tags: {
+			gnre: ['hackandslash', 'live-action', 'adventure'],
+			media: ['cards', 'tv', 'movies', 'games', 'books'],
+			theme: ['dragon', 'heroes', 'sword', 'magic'],
+			tv: ['amazon'],
+		},
+		taxonomies: ['ent', 'movies'],
+		openRtb2ContentCategories: [
+			OpenRtb2ContentCategories.BOOKS,
+			OpenRtb2ContentCategories.MOVIES,
+			OpenRtb2ContentCategories.TV,
+			OpenRtb2ContentCategories.GAMES,
+			OpenRtb2ContentCategories.CARD_GAMES,
+		],
+	},
+	{
+		testName: 'Harry Potter wiki',
+		categories: ['ent', 'movies'],
+		tags: {
+			gnre: ['live-action', 'war'],
+			media: ['movies', 'games', 'books'],
+			theme: ['school', 'villains'],
+		},
+		taxonomies: ['ent', 'movies'],
+		openRtb2ContentCategories: [
+			OpenRtb2ContentCategories.BOOKS,
+			OpenRtb2ContentCategories.MOVIES,
+			OpenRtb2ContentCategories.GAMES,
+		],
+	},
+	{
+		testName: 'StarWars wiki',
+		categories: ['ent', 'tv', 'videogames', 'books', 'comics', 'movies'],
+		tags: {
+			gnre: ['mmorpg'],
+			media: ['movies', 'games', 'books'],
+			theme: ['alien', 'villians'],
+			tv: ['cn', 'disney'],
+		},
+		taxonomies: ['ent', 'movies'],
+		openRtb2ContentCategories: [
+			OpenRtb2ContentCategories.BOOKS,
+			OpenRtb2ContentCategories.MOVIES,
+			OpenRtb2ContentCategories.TV,
+			OpenRtb2ContentCategories.COMIC_BOOKS,
+			OpenRtb2ContentCategories.GAMES,
+		],
+	},
+	{
+		testName: 'U2 wiki',
+		categories: ['music'],
+		tags: {
+			gnre: ['singing'],
+			media: ['music', 'web', 'tv', 'movies', 'games', 'books'],
+			theme: ['documentary', 'music'],
+		},
+		taxonomies: ['ent', 'music'],
+		openRtb2ContentCategories: [
+			OpenRtb2ContentCategories.BOOKS,
+			OpenRtb2ContentCategories.MOVIES,
+			OpenRtb2ContentCategories.MUSIC,
+			OpenRtb2ContentCategories.TV,
+			OpenRtb2ContentCategories.GAMES,
+		],
+	},
+	{
+		testName: 'FIFA wiki',
+		categories: ['gaming'],
+		tags: {
+			gnre: ['esports', 'sports'],
+			media: ['games'],
+			theme: ['soccer'],
+		},
+		taxonomies: ['gaming', 'games'],
+		openRtb2ContentCategories: [OpenRtb2ContentCategories.GAMES],
+	},
+];
+
+describe('OpenRtb2Tags', () => {
+	beforeEach(() => {
+		global.sandbox.stub(window, 'location').value({
+			hostname: pageHostname,
+		});
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: () => ({ matches: false }),
+		});
+	});
+
+	testCases.forEach(({ testName, categories, tags, taxonomies, openRtb2ContentCategories }) =>
+		it(`should return OpenRtb2Tags correctly for ${testName}`, () => {
+			// given
+			const mockedContext: FandomContext = new FandomContext(
+				new Site(categories, true, 'test', false, tags, taxonomies),
+				new Page(666, pageLang, pageId, pageName, 'article-test', {}, 546),
+			);
+			const openRtb2Tags = new OpenRtb2Tags(mockedContext);
+			const expectedOpenRtb2Object = createExpectedOpenRtb2Object(openRtb2ContentCategories, tags);
+
+			// when
+			const openRtb2Object = openRtb2Tags.get();
+
+			// then
+			expect(openRtb2Object).to.deep.equal(expectedOpenRtb2Object);
+		}),
+	);
+});

--- a/src/ad-bidders/a9/index.ts
+++ b/src/ad-bidders/a9/index.ts
@@ -159,6 +159,9 @@ export class A9Provider extends BidderProvider {
 			videoAdServer: 'DFP',
 			deals: true,
 			...A9Provider.getCcpaIfApplicable(signalData),
+			signals: {
+				ortb2: targetingService.get('openrtb2'),
+			},
 		};
 	}
 

--- a/src/ad-bidders/a9/types.ts
+++ b/src/ad-bidders/a9/types.ts
@@ -1,4 +1,5 @@
 import { Dictionary } from '@ad-engine/core';
+import { OpenRtb2Object } from '../../platforms/shared';
 import { BidderConfig, BidsRefreshing } from '../bidder-provider';
 
 export type PriceMap = Dictionary<string>;
@@ -7,6 +8,9 @@ export interface ApstagConfig extends Partial<A9CCPA> {
 	pubID: string;
 	videoAdServer: 'DFP';
 	deals: boolean;
+	signals: {
+		ortb2: OpenRtb2Object;
+	};
 }
 
 export interface A9CCPA {

--- a/src/platforms/shared/context/targeting/targeting-strategies/factories/create-open-rtb2-context.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/factories/create-open-rtb2-context.ts
@@ -1,0 +1,7 @@
+import { FandomContext } from '../models/fandom-context';
+import { OpenRtb2Object } from '../models/open-rtb2';
+import { OpenRtb2Tags } from '../providers/open-rtb2-tags';
+
+export function createOpenRtb2Context(fandomContext: FandomContext): OpenRtb2Object {
+	return new OpenRtb2Tags(fandomContext).get();
+}

--- a/src/platforms/shared/context/targeting/targeting-strategies/models/fandom-context.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/models/fandom-context.ts
@@ -8,7 +8,7 @@ export class FandomContext {
 }
 
 export class Site {
-	public readonly categories: [];
+	public readonly categories: string[];
 	public readonly directedAtChildren: boolean;
 	public readonly esrbRating: string;
 	public readonly siteName: string;
@@ -18,7 +18,7 @@ export class Site {
 	public readonly mpaRating: string;
 
 	constructor(
-		categories: [],
+		categories: string[],
 		directedAtChildren: boolean,
 		siteName: string,
 		top1000: boolean,

--- a/src/platforms/shared/context/targeting/targeting-strategies/models/open-rtb2.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/models/open-rtb2.ts
@@ -1,0 +1,37 @@
+/**
+ * @see: https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf
+ * OpenRTB2.5 is only used by A9 which implements Site and User sections.
+ * From FandomContext we can obtain details about Site.
+ */
+export interface OpenRtb2Object {
+	// Section 3.2.13 - Object: Site
+	site: {
+		id: string;
+		name: string;
+		domain: string;
+		cat: OpenRtb2ContentCategories[];
+		mobile: 0 | 1;
+		// Section 3.2.16 - Object: Content
+		content: {
+			language: string;
+			// Section 5.18 - Content Context
+			context: number;
+		};
+		keywords: string;
+	};
+	// Section 3.2.20 - Object: User
+	user: Record<string, never>; // currently not used
+}
+
+// Section: 5.1 - Content Categories
+export enum OpenRtb2ContentCategories {
+	// IAB1 Arts & Entertainment
+	BOOKS = 'IAB1-1',
+	MOVIES = 'IAB1-5',
+	MUSIC = 'IAB1-6',
+	TV = 'IAB1-7',
+	// IAB9 Hobbies & Interests
+	CARD_GAMES = 'IAB9-7',
+	COMIC_BOOKS = 'IAB9-11',
+	GAMES = 'IAB9-30',
+}

--- a/src/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.ts
@@ -1,0 +1,82 @@
+import { utils } from '@wikia/core';
+import { TargetingProvider } from '../interfaces/targeting-provider';
+import { FandomContext } from '../models/fandom-context';
+import { OpenRtb2ContentCategories, OpenRtb2Object } from '../models/open-rtb2';
+
+const openRtb2ContentCategoryMap: Record<string, OpenRtb2ContentCategories> = {
+	books: OpenRtb2ContentCategories.BOOKS,
+	cards: OpenRtb2ContentCategories.CARD_GAMES,
+	movie: OpenRtb2ContentCategories.MOVIES,
+	movies: OpenRtb2ContentCategories.MOVIES,
+	music: OpenRtb2ContentCategories.MUSIC,
+	comics: OpenRtb2ContentCategories.COMIC_BOOKS,
+	tv: OpenRtb2ContentCategories.TV,
+	games: OpenRtb2ContentCategories.GAMES,
+	gaming: OpenRtb2ContentCategories.GAMES,
+	videogames: OpenRtb2ContentCategories.GAMES,
+};
+
+export class OpenRtb2Tags implements TargetingProvider<OpenRtb2Object> {
+	private readonly categories: Set<OpenRtb2ContentCategories> =
+		new Set<OpenRtb2ContentCategories>();
+
+	constructor(private fandomContext: FandomContext) {}
+
+	get(): OpenRtb2Object {
+		const { page, site } = this.fandomContext;
+
+		const categories = this.getCategories(site);
+		const keywords = this.getKeywords(site);
+
+		return {
+			site: {
+				id: page.pageId?.toString(),
+				name: page.pageName,
+				domain: window.location.hostname,
+				cat: categories,
+				mobile: utils.client.getDeviceMode() === 'mobile' ? 1 : 0,
+				content: {
+					language: page.lang,
+					context: 5,
+				},
+				keywords,
+			},
+			user: {},
+		};
+	}
+
+	private getCategories(site: FandomContext['site']): OpenRtb2ContentCategories[] {
+		const categories = [...site.categories, ...site.taxonomy];
+		categories.forEach((category) => this.addCategory(category));
+
+		if (categories.includes('ent')) {
+			const tags = site.tags.media ?? [];
+
+			tags.forEach((tag) => this.addCategory(tag));
+		}
+
+		return [...this.categories].sort();
+	}
+
+	private addCategory(category: string): void {
+		const openRtb2ContentCategory = openRtb2ContentCategoryMap[category];
+
+		if (openRtb2ContentCategory) {
+			this.categories.add(openRtb2ContentCategory);
+		}
+	}
+
+	private getKeywords(site: FandomContext['site']): string {
+		return [
+			...new Set([
+				...(site.tags.gnre ?? []),
+				...(site.tags.media ?? []),
+				...(site.tags.theme ?? []),
+				...(site.tags.tv ?? []),
+			]),
+		]
+			.filter(Boolean)
+			.sort()
+			.join(',');
+	}
+}

--- a/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
+++ b/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
@@ -54,8 +54,7 @@ export class UcpTargetingSetup implements DiProcess {
 			utils.targeting.getTargetingBundles(this.instantConfig.get('icTargetingBundles')),
 		);
 
-		// At the moment, only A9 uses OpenRTB2.5 standard
-		if (context.get('bidders.a9.enabled')) {
+		if (this.instantConfig.get<boolean>('icOpenRtb2Context')) {
 			targetingService.set('openrtb2', createOpenRtb2Context(fandomContext));
 		}
 	}

--- a/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
+++ b/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
@@ -10,17 +10,21 @@ import {
 } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { createFandomContext } from './targeting-strategies/factories/create-fandom-context';
+import { createOpenRtb2Context } from './targeting-strategies/factories/create-open-rtb2-context';
 import { createSelectedStrategy } from './targeting-strategies/factories/create-selected-strategy';
 import { TargetingTags } from './targeting-strategies/interfaces/taxonomy-tags';
+import { FandomContext } from './targeting-strategies/models/fandom-context';
 
 @Injectable()
 export class UcpTargetingSetup implements DiProcess {
 	constructor(protected instantConfig: InstantConfigService) {}
 
 	execute(): void {
+		const fandomContext = createFandomContext();
+
 		targetingService.extend({
 			...targetingService.dump(),
-			...this.getPageLevelTargeting(),
+			...this.getPageLevelTargeting(fandomContext),
 		});
 
 		if (context.get('wiki.opts.isAdTestWiki') && context.get('wiki.targeting.testSrc')) {
@@ -49,13 +53,18 @@ export class UcpTargetingSetup implements DiProcess {
 			'bundles',
 			utils.targeting.getTargetingBundles(this.instantConfig.get('icTargetingBundles')),
 		);
+
+		// At the moment, only A9 uses OpenRTB2.5 standard
+		if (context.get('bidders.a9.enabled')) {
+			targetingService.set('openrtb2', createOpenRtb2Context(fandomContext));
+		}
 	}
 
-	private getPageLevelTargeting(): TargetingTags {
+	private getPageLevelTargeting(fandomContext: FandomContext): TargetingTags {
 		const selectedStrategy: string = this.instantConfig.get('icTargetingStrategy');
 
 		utils.logger('Targeting', `Selected targeting priority strategy: ${selectedStrategy}`);
 
-		return createSelectedStrategy(selectedStrategy, createFandomContext()).get();
+		return createSelectedStrategy(selectedStrategy, fandomContext).get();
 	}
 }

--- a/src/platforms/shared/index.ts
+++ b/src/platforms/shared/index.ts
@@ -1,6 +1,7 @@
 export * from './bidders/bidders-state.setup';
 export * from './bidders/wikia-adapter';
 export * from './bootstrap';
+export * from './context/targeting/targeting-strategies/models/open-rtb2';
 export * from './context/targeting/ucp-targeting.setup';
 export * from './dynamic-slots/fan-feed-native-ad-listener';
 export * from './dynamic-slots/nativo-slots-definition-repository';


### PR DESCRIPTION
This PR implements OpenRTB API 2.5 specification and to do so it uses the data gathered from `FandomContext`. The created OpenRTB object is then used by Amazon A9 via `apstag.init` method. Amazon only implemented OpenRTB's `user` and `site` objects and we can only provide `site` data at the moment (maybe we will provide some user data in the future).