### PR TITLE
ADEN-13053 Fix TypeError in OpenRtb2Tags

### DIFF
--- a/spec/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.spec.ts
+++ b/spec/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.spec.ts
@@ -17,7 +17,9 @@ const createExpectedOpenRtb2Object = (
 	tags: Dictionary<string[]> = {},
 	mobile: 0 | 1 = 0,
 ): OpenRtb2Object => {
-	const keywords = [...new Set(Object.keys(tags).flatMap((key) => tags[key]))].sort().join(',');
+	const keywords = tags
+		? [...new Set(Object.keys(tags).flatMap((key) => tags[key]))].sort().join(',')
+		: '';
 
 	return {
 		site: {
@@ -46,6 +48,13 @@ const testCases: {
 		testName: 'empty fandomContext',
 		categories: [],
 		tags: {},
+		taxonomies: [],
+		openRtb2ContentCategories: [],
+	},
+	{
+		testName: 'null tags fandomContext',
+		categories: ['ent'],
+		tags: null,
 		taxonomies: [],
 		openRtb2ContentCategories: [],
 	},

--- a/src/platforms/shared/context/targeting/targeting-strategies/models/fandom-context.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/models/fandom-context.ts
@@ -13,7 +13,7 @@ export class Site {
 	public readonly esrbRating: string;
 	public readonly siteName: string;
 	public readonly top1000: boolean;
-	public readonly tags: TaxonomyTags;
+	public readonly tags: TaxonomyTags | null;
 	public readonly taxonomy: string[];
 	public readonly mpaRating: string;
 

--- a/src/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.ts
@@ -49,10 +49,8 @@ export class OpenRtb2Tags implements TargetingProvider<OpenRtb2Object> {
 		const categories = [...site.categories, ...site.taxonomy];
 		categories.forEach((category) => this.addCategory(category));
 
-		if (categories.includes('ent')) {
-			const tags = site.tags.media ?? [];
-
-			tags.forEach((tag) => this.addCategory(tag));
+		if (categories.includes('ent') && site?.tags?.media) {
+			site.tags.media.forEach((tag) => this.addCategory(tag));
 		}
 
 		return [...this.categories].sort();
@@ -67,6 +65,10 @@ export class OpenRtb2Tags implements TargetingProvider<OpenRtb2Object> {
 	}
 
 	private getKeywords(site: FandomContext['site']): string {
+		if (!site?.tags) {
+			return '';
+		}
+
 		return [
 			...new Set([
 				...(site.tags.gnre ?? []),


### PR DESCRIPTION
## Description
Apparently `window.fandomContext.site.tags` can be either object or null... What a pity that TypeScript typings do not reflect that at all.
This is a quick fix to OpenRtb2Tags so it handles a situation when `window.fandomContext.site.tags` is set to null.

I will go and fix `FandomContext` typings in separate PR so they are in line with the reality. We have TypeScript so let's use it to our advantage, not the other way around.