### PR TITLE
Fix OpenRTB2 object getting into VAST params

### DIFF
--- a/src/ad-bidders/a9/index.ts
+++ b/src/ad-bidders/a9/index.ts
@@ -160,7 +160,7 @@ export class A9Provider extends BidderProvider {
 			deals: true,
 			...A9Provider.getCcpaIfApplicable(signalData),
 			signals: {
-				ortb2: targetingService.get('openrtb2'),
+				ortb2: targetingService.get('openrtb2', 'openrtb2'),
 			},
 		};
 	}

--- a/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
+++ b/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
@@ -55,7 +55,7 @@ export class UcpTargetingSetup implements DiProcess {
 		);
 
 		if (this.instantConfig.get<boolean>('icOpenRtb2Context')) {
-			targetingService.set('openrtb2', createOpenRtb2Context(fandomContext));
+			targetingService.set('openrtb2', createOpenRtb2Context(fandomContext), 'openrtb2');
 		}
 	}
 


### PR DESCRIPTION
## Description
The problem was spotted by @kwfandom and it could be reproduced when visiting https://project43.fandom.com/wiki/SyntheticTests/Premium/FeaturedVideo/JWPlayer?adengine_version=v139.0.7&icbm__icOpenRtb2Context=true

If you run `document.querySelector('.desktop-article-video-wrapper div:nth-child(2)').getAttribute('data-vast-params').indexOf('object Object')` after visiting the page you will receive some index that indicates the `object Object]` phrase is included in VAST params.

Due to the way `targetingService` works, when it gets dumped it returns all the items. I have used `targetingService` to pass OpenRTB2 data created in `UcpTargetingSetup`, but then it would get included in all different places, one of them being VAST params. The fix introduces "fake" AdSlot for OpenRTB2 so the data is not accidently used.