### PR TITLE
ADEN-13109 Base verticalName on 'adtags' meta tag on N&R sites

### DIFF
--- a/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
@@ -38,5 +38,17 @@ describe('Gamespot Targeting Setup', () => {
 			// then
 			expect(verticalName).to.equal('gaming');
 		});
+
+		it('defaults to  "gaming" when verticalName is not available', () => {
+			// given
+			const gamespotTargetingSetup = new GamespotTargetingSetup();
+			targetingServiceStub.get.withArgs('verticalName').returns(undefined);
+
+			// when
+			const verticalName = gamespotTargetingSetup.getVerticalName();
+
+			// then
+			expect(verticalName).to.equal('gaming');
+		});
 	});
 });

--- a/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
@@ -10,6 +10,10 @@ describe('Gamespot Targeting Setup', () => {
 		targetingServiceStub = global.sandbox.stub(targetingService);
 	});
 
+	afterEach(() => {
+		global.sandbox.restore();
+	});
+
 	describe('getVerticalName', () => {
 		it('returns "ent" when verticalName="ent"', () => {
 			// given

--- a/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
@@ -1,192 +1,37 @@
+import { TargetingService, targetingService } from '@wikia/core';
 import { GamespotTargetingSetup } from '@wikia/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup';
 import { expect } from 'chai';
+import { SinonStubbedInstance } from 'sinon';
 
 describe('Gamespot Targeting Setup', () => {
-	afterEach(() => {
-		window.utag_data = undefined;
+	let targetingServiceStub: SinonStubbedInstance<TargetingService>;
+
+	beforeEach(() => {
+		targetingServiceStub = global.sandbox.stub(targetingService);
 	});
 
 	describe('getVerticalName', () => {
-		it('returns "gaming" when utag_data is not available', () => {
+		it('returns "ent" when verticalName="ent"', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
+			targetingServiceStub.get.withArgs('verticalName').returns('ent');
 
-			//when
+			// when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
 
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "ent" when isEnterteinmentSite() returns true', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { 'dom.pathname': '/entertainment' };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
+			// then
 			expect(verticalName).to.equal('ent');
 		});
 
-		it('returns "gaming" on siteSection=news when topicName is not available', () => {
+		it('returns "gaming" when verticalName="gaming"', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'news' };
+			targetingServiceStub.get.withArgs('verticalName').returns('gaming');
 
-			//when
+			// when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
 
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "gaming" on siteSection=news when topicName is empty array', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'news' };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "gaming" on siteSection=news when topicName array include "Games"', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'news', topicName: ['Games'] };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "gaming" on siteSection=news when topicName does not include "Games" but contentTopicId does', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = {
-				siteSection: 'news',
-				topicName: ['Tech'],
-				contentTopicName: 'gaming-tech',
-			};
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "ent" on siteSection=news when topicName array does not include "Games"', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'news', topicName: ['TV'] };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('ent');
-		});
-
-		it('returns "gaming" on siteSection=reviews when topicName array include "Games"', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'reviews', topicName: ['Games'] };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "gaming" on siteSection=reviews when topicName array include "Game Review"', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'reviews', topicName: ['Games'] };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "ent" on siteSection=reviews when topicName array does not include "Games"', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'reviews', topicName: ['TV'] };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('ent');
-		});
-
-		it('returns "gaming" on siteSection=galleries when topicName array include "Games"', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'galleries', topicName: ['Games'] };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "ent" on siteSection=galleries when topicName array does not include "Games"', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'galleries', topicName: ['TV'] };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('ent');
-		});
-
-		it('returns "gaming" on siteSection=reviews when topicName is not available', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'news' };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "gaming" when siteSection does not exist', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = {};
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "gaming" when siteSection is different than news and entertainment', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.utag_data = { siteSection: 'different' };
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
+			// then
 			expect(verticalName).to.equal('gaming');
 		});
 	});

--- a/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
@@ -11,6 +11,10 @@ describe('Metacritic Targeting Setup', () => {
 		window.utag_data = undefined;
 	});
 
+	afterEach(() => {
+		global.sandbox.restore();
+	});
+
 	describe('getVerticalName', () => {
 		it('returns "gaming" when utag_data is available and siteSection equals to "games"', () => {
 			// given

--- a/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
@@ -1,40 +1,89 @@
+import { targetingService, TargetingService } from '@wikia/core';
 import { MetacriticTargetingSetup } from '@wikia/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup';
 import { expect } from 'chai';
+import { SinonStubbedInstance } from 'sinon';
 
 describe('Metacritic Targeting Setup', () => {
-	afterEach(() => {
+	let targetingServiceStub: SinonStubbedInstance<TargetingService>;
+
+	beforeEach(() => {
+		targetingServiceStub = global.sandbox.stub(targetingService);
 		window.utag_data = undefined;
 	});
 
-	it('getVerticalName() returns "gaming" on gaming section sites', () => {
-		window.utag_data = { siteSection: 'games' };
+	describe('getVerticalName', () => {
+		it('returns "gaming" when utag_data.siteSection equals to "games"', () => {
+			// given
+			window.utag_data = { siteSection: 'games' };
+			targetingServiceStub.get.withArgs('verticalName').returns('ent');
 
-		const verticalName = new MetacriticTargetingSetup().getVerticalName();
+			// when
+			const verticalName = new MetacriticTargetingSetup().getVerticalName();
 
-		expect(verticalName).to.equal('gaming');
+			// then
+			expect(verticalName).to.equal('gaming');
+		});
+
+		it('returns "gaming" when utag_data not available and "verticalName" equals to "gaming" ', () => {
+			// given
+			window.utag_data = undefined;
+			targetingServiceStub.get.withArgs('verticalName').returns('gaming');
+
+			// when
+			const verticalName = new MetacriticTargetingSetup().getVerticalName();
+
+			// then
+			expect(verticalName).to.equal('ent');
+		});
+
+		it('returns "ent" when utag_data.siteSection is different than "games"', () => {
+			// given
+			window.utag_data = { siteSection: 'test' };
+			targetingServiceStub.get.withArgs('verticalName').returns('gaming');
+
+			// when
+			const verticalName = new MetacriticTargetingSetup().getVerticalName();
+
+			// then
+			expect(verticalName).to.equal('ent');
+		});
+
+		it('returns "ent" when utag_data not available and "verticalName" equals to "ent" ', () => {
+			// given
+			window.utag_data = undefined;
+			targetingServiceStub.get.withArgs('verticalName').returns('ent');
+
+			// when
+			const verticalName = new MetacriticTargetingSetup().getVerticalName();
+
+			// then
+			expect(verticalName).to.equal('ent');
+		});
 	});
 
-	it('getVerticalName() returns "ent" on section sites different than gaming', () => {
-		window.utag_data = { siteSection: 'movies' };
+	describe('getPageType', () => {
+		it('return pageType from utag_data when it is available', () => {
+			// given
+			window.utag_data = { pageType: 'utag_data_ptype' };
+			targetingServiceStub.get.withArgs('ptype').returns('targeting_service_ptype');
 
-		const verticalName = new MetacriticTargetingSetup().getVerticalName();
+			// when
+			const pageType = new MetacriticTargetingSetup().getPageType();
 
-		expect(verticalName).to.equal('ent');
-	});
+			// then
+			expect(pageType).to.equal('utag_data_ptype');
+		});
 
-	it('getPageType() returns correct pageType from utag_data', () => {
-		window.utag_data = { pageType: 'article' };
+		it('return pageType from targetingService when utag_data is not available', () => {
+			// given
+			window.utag_data = undefined;
+			targetingServiceStub.get.withArgs('ptype').returns('targeting_service_ptype');
 
-		const ptype = new MetacriticTargetingSetup().getPageType();
+			// when
+			const pageType = new MetacriticTargetingSetup().getPageType();
 
-		expect(ptype).to.equal('article');
-	});
-
-	it('getPageType() returns undefined when pageType is missing from utag_data', () => {
-		window.utag_data = { siteType: 'article' };
-
-		const ptype = new MetacriticTargetingSetup().getPageType();
-
-		expect(ptype).to.be.undefined;
+			// then
+			expect(pageType).to.equal('targeting_service_ptype');
+		});
 	});
 });

--- a/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
@@ -12,7 +12,7 @@ describe('Metacritic Targeting Setup', () => {
 	});
 
 	describe('getVerticalName', () => {
-		it('returns "gaming" when utag_data.siteSection equals to "games"', () => {
+		it('returns "gaming" when utag_data is available and siteSection equals to "games"', () => {
 			// given
 			window.utag_data = { siteSection: 'games' };
 			targetingServiceStub.get.withArgs('verticalName').returns('ent');
@@ -24,7 +24,19 @@ describe('Metacritic Targeting Setup', () => {
 			expect(verticalName).to.equal('gaming');
 		});
 
-		it('returns "gaming" when utag_data not available and "verticalName" equals to "gaming" ', () => {
+		it('returns "ent" when utag_data is available and siteSection is different than "games"', () => {
+			// given
+			window.utag_data = { siteSection: 'different_than_games' };
+			targetingServiceStub.get.withArgs('verticalName').returns('gaming');
+
+			// when
+			const verticalName = new MetacriticTargetingSetup().getVerticalName();
+
+			// then
+			expect(verticalName).to.equal('ent');
+		});
+
+		it('returns "gaming" when utag_data is not available and "verticalName" equals to "gaming" ', () => {
 			// given
 			window.utag_data = undefined;
 			targetingServiceStub.get.withArgs('verticalName').returns('gaming');
@@ -33,22 +45,10 @@ describe('Metacritic Targeting Setup', () => {
 			const verticalName = new MetacriticTargetingSetup().getVerticalName();
 
 			// then
-			expect(verticalName).to.equal('ent');
+			expect(verticalName).to.equal('gaming');
 		});
 
-		it('returns "ent" when utag_data.siteSection is different than "games"', () => {
-			// given
-			window.utag_data = { siteSection: 'test' };
-			targetingServiceStub.get.withArgs('verticalName').returns('gaming');
-
-			// when
-			const verticalName = new MetacriticTargetingSetup().getVerticalName();
-
-			// then
-			expect(verticalName).to.equal('ent');
-		});
-
-		it('returns "ent" when utag_data not available and "verticalName" equals to "ent" ', () => {
+		it('returns "ent" when utag_data is not available and "verticalName" equals to "ent" ', () => {
 			// given
 			window.utag_data = undefined;
 			targetingServiceStub.get.withArgs('verticalName').returns('ent');

--- a/src/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.ts
@@ -13,7 +13,7 @@ export class GamespotTargetingSetup implements DiProcess {
 		targetingService.extend(targeting);
 	}
 
-	getVerticalName(): 'gaming' | 'ent' {
+	getVerticalName(): string | undefined {
 		return targetingService.get('verticalName');
 	}
 }

--- a/src/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.ts
@@ -14,50 +14,6 @@ export class GamespotTargetingSetup implements DiProcess {
 	}
 
 	getVerticalName(): 'gaming' | 'ent' {
-		const utagData = window.utag_data;
-		if (!utagData) {
-			return 'gaming';
-		}
-
-		if (this.isEntertainmentSite(utagData['dom.pathname'])) {
-			return 'ent';
-		}
-
-		if (
-			utagData.siteSection === 'news' ||
-			utagData.siteSection === 'reviews' ||
-			utagData.siteSection === 'galleries'
-		) {
-			return this.getVerticalNameBasedOnTopicName(utagData);
-		}
-
-		return 'gaming';
-	}
-
-	isEntertainmentSite(pathname: string): boolean {
-		if (!pathname) {
-			return false;
-		}
-
-		return pathname.includes('entertainment');
-	}
-
-	private getVerticalNameBasedOnTopicName(utagData): 'gaming' | 'ent' {
-		const topicName = utagData.topicName;
-		const contentTopicName = utagData.contentTopicName;
-
-		if (!Array.isArray(topicName) || topicName.length === 0) {
-			return 'gaming';
-		}
-
-		if (topicName.includes('Games') || topicName.includes('Game Review')) {
-			return 'gaming';
-		}
-
-		if (contentTopicName && contentTopicName.includes('gaming')) {
-			return 'gaming';
-		}
-
-		return 'ent';
+		return targetingService.get('verticalName');
 	}
 }

--- a/src/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.ts
@@ -14,6 +14,6 @@ export class GamespotTargetingSetup implements DiProcess {
 	}
 
 	getVerticalName(): string | undefined {
-		return targetingService.get('verticalName');
+		return targetingService.get('verticalName') || 'gaming';
 	}
 }

--- a/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
@@ -13,10 +13,12 @@ export class MetacriticTargetingSetup implements DiProcess {
 	}
 
 	getVerticalName(): 'gaming' | 'ent' {
-		return window.utag_data?.siteSection === 'games' ? 'gaming' : 'ent';
+		return window.utag_data?.siteSection === 'games'
+			? 'gaming'
+			: 'ent' || targetingService.get('verticalName');
 	}
 
 	getPageType(): string | undefined {
-		return window.utag_data?.pageType;
+		return window.utag_data?.pageType || targetingService.get('ptype');
 	}
 }

--- a/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
@@ -13,9 +13,15 @@ export class MetacriticTargetingSetup implements DiProcess {
 	}
 
 	getVerticalName(): 'gaming' | 'ent' {
-		return window.utag_data?.siteSection === 'games'
-			? 'gaming'
-			: 'ent' || targetingService.get('verticalName');
+		let verticalName;
+
+		if (window.utag_data?.siteSection) {
+			verticalName = window.utag_data.siteSection === 'games' ? 'gaming' : 'ent';
+		} else {
+			verticalName = targetingService.get('verticalName');
+		}
+
+		return verticalName;
 	}
 
 	getPageType(): string | undefined {

--- a/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
@@ -12,7 +12,7 @@ export class MetacriticTargetingSetup implements DiProcess {
 		targetingService.extend(targeting);
 	}
 
-	getVerticalName(): 'gaming' | 'ent' {
+	getVerticalName(): string | undefined {
 		let verticalName;
 
 		if (window.utag_data?.siteSection) {

--- a/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
@@ -13,15 +13,11 @@ export class MetacriticTargetingSetup implements DiProcess {
 	}
 
 	getVerticalName(): string | undefined {
-		let verticalName;
-
 		if (window.utag_data?.siteSection) {
-			verticalName = window.utag_data.siteSection === 'games' ? 'gaming' : 'ent';
-		} else {
-			verticalName = targetingService.get('verticalName');
+			return window.utag_data.siteSection === 'games' ? 'gaming' : 'ent';
 		}
 
-		return verticalName;
+		return targetingService.get('verticalName');
 	}
 
 	getPageType(): string | undefined {


### PR DESCRIPTION
### Ticket
https://fandom.atlassian.net/browse/ADEN-13109

### Description
Removal of Tealium, so `window.utag_data` object is currently in progress on N&R sites.
We base verticalName (s0) key for sites Gamespot and Metacritic on `utag_data` so it should be changed to be based on `adtags` meta data object.