### PR TITLE
ADEN-12110 - Removed COPPA-related flags

### DIFF
--- a/src/ad-bidders/a9/index.ts
+++ b/src/ad-bidders/a9/index.ts
@@ -69,8 +69,7 @@ export class A9Provider extends BidderProvider {
 
 	public static isEnabled(): boolean {
 		const enabled = context.get('bidders.a9.enabled');
-		const coppaA9 = context.get('bidders.coppaA9');
-		return enabled && (coppaA9 ? !utils.isCoppaSubject() : true);
+		return enabled && !utils.isCoppaSubject();
 	}
 
 	private loaded = false;

--- a/src/core/services/config-service.ts
+++ b/src/core/services/config-service.ts
@@ -1,5 +1,3 @@
-import { context } from './context-service';
-
 /*
  *  ToDo: Development improvement refactor
  *  This class is about to be expanded in ADEN-10310
@@ -8,8 +6,8 @@ class Config {
 	public rollout = {
 		coppaFlag: () => {
 			return {
-				gam: context.get('options.coppaGam'),
-				prebid: context.get('options.coppaPrebid'),
+				gam: true,
+				prebid: true,
 			};
 		},
 	};

--- a/src/platforms/shared/bidders/bidders-state.setup.ts
+++ b/src/platforms/shared/bidders/bidders-state.setup.ts
@@ -39,7 +39,6 @@ export class BiddersStateSetup implements DiProcess {
 
 		if (this.instantConfig.get('icA9Bidder')) {
 			context.set('bidders.a9.enabled', true);
-			context.set('bidders.coppaA9', this.instantConfig.get('icCoppaA9'));
 			context.set(
 				'bidders.a9.videoEnabled',
 				this.instantConfig.get('icA9VideoBidder') && hasFeaturedVideo,

--- a/src/platforms/shared/setup/base-context.setup.ts
+++ b/src/platforms/shared/setup/base-context.setup.ts
@@ -118,8 +118,6 @@ export class BaseContextSetup implements DiProcess {
 			'options.video.comscoreJwpTracking',
 			this.instantConfig.get('icComscoreJwpTracking'),
 		);
-		context.set('options.coppaGam', this.instantConfig.get('icCoppaGam'));
-		context.set('options.coppaPrebid', this.instantConfig.get('icCoppaPrebid'));
 
 		this.setWadContext();
 	}


### PR DESCRIPTION
In this PR I've removed Feature Flags, that were responsible for turning on COPPA integration in bidders. Those flags were :
- icCoppaGam
- icCoppaA9
- icCoppaPrebid
After this PR is merged, it should not be possible to turn off that integration by using ICBM