### PR TITLE
UXFCP-3744 (chore): Remove slot for desktop.

### DIFF
--- a/src/platforms/ucp-desktop/setup/context/slots/ucp-desktop-slots-context.setup.ts
+++ b/src/platforms/ucp-desktop/setup/context/slots/ucp-desktop-slots-context.setup.ts
@@ -143,11 +143,6 @@ export class UcpDesktopSlotsContextSetup implements DiProcess {
 				trackEachStatus: true,
 				trackingKey: 'featured-video',
 			},
-			ntv_feed_ad: {
-				providers: ['nativo'],
-				trackEachStatus: true,
-				isNative: true,
-			},
 			quiz_leaderboard_start: {
 				adProduct: 'quiz_leaderboard_start',
 				defaultSizes: [


### PR DESCRIPTION
With UCP pull request we will be removing logic for pulling sponsored tile to fan-feed (recirculation footer) on desktop.

Ticket: https://fandom.atlassian.net/browse/UXFCP-3744
Origin: https://github.com/Wikia/unified-platform/pull/14026
Ad-tests: (to be added)