### PR TITLE
ADEN-13294 Handle icMonitorTrafficThreshold being JSON object

### DIFF
--- a/spec/platforms/shared/setup/metric-reporter.setup.spec.ts
+++ b/spec/platforms/shared/setup/metric-reporter.setup.spec.ts
@@ -3,9 +3,9 @@ import { MetricReporterSetup } from '@wikia/platforms/shared';
 import { expect } from 'chai';
 
 describe('MetricReporterSetup', () => {
-	it('should set values to the context', async () => {
+	it('should set values to the context (number threshold)', async () => {
 		const instantConfig = {
-			get: () => 'xyz',
+			get: () => 1,
 		} as any;
 		const metricSetup = new MetricReporterSetup(instantConfig);
 
@@ -15,6 +15,22 @@ describe('MetricReporterSetup', () => {
 		expect(contextSetSpy.callCount).to.be.eq(3);
 		expect(context.get('services.monitoring.endpoint')).to.not.be.empty;
 		expect(context.get('services.monitoring.service')).to.not.be.empty;
-		expect(context.get('services.monitoring.threshold')).to.not.be.empty;
+		expect(context.get('services.monitoring-default.threshold')).to.be.eq(1);
+	});
+
+	it('should set values to the context (object threshold)', async () => {
+		const instantConfig = {
+			get: () => ({ default: 10, feature: 5 }),
+		} as any;
+		const metricSetup = new MetricReporterSetup(instantConfig);
+
+		const contextSetSpy = global.sandbox.spy(context, 'set');
+		await metricSetup.execute();
+
+		expect(contextSetSpy.callCount).to.be.eq(4);
+		expect(context.get('services.monitoring.endpoint')).to.not.be.empty;
+		expect(context.get('services.monitoring.service')).to.not.be.empty;
+		expect(context.get('services.monitoring-default.threshold')).to.be.eq(10);
+		expect(context.get('services.monitoring-feature.threshold')).to.be.eq(5);
 	});
 });

--- a/src/platforms/shared/setup/metric-reporter.setup.ts
+++ b/src/platforms/shared/setup/metric-reporter.setup.ts
@@ -9,7 +9,9 @@ export class MetricReporterSetup implements DiProcess {
 		const serviceUrl = utils.getServicesBaseURL() || '';
 		context.set('services.monitoring.endpoint', serviceUrl.replace(/\/+$/, ''));
 		context.set('services.monitoring.service', 'adeng');
-		const icMonitorTrafficThreshold = this.instantConfig.get('icMonitorTrafficThreshold', {});
+		const icMonitorTrafficThreshold = this.instantConfig.get('icMonitorTrafficThreshold', {
+			default: 0,
+		});
 		const monitorTrafficThreshold =
 			typeof icMonitorTrafficThreshold === 'number'
 				? { default: icMonitorTrafficThreshold }

--- a/src/platforms/shared/setup/metric-reporter.setup.ts
+++ b/src/platforms/shared/setup/metric-reporter.setup.ts
@@ -9,9 +9,13 @@ export class MetricReporterSetup implements DiProcess {
 		const serviceUrl = utils.getServicesBaseURL() || '';
 		context.set('services.monitoring.endpoint', serviceUrl.replace(/\/+$/, ''));
 		context.set('services.monitoring.service', 'adeng');
-		context.set(
-			'services.monitoring.threshold',
-			this.instantConfig.get('icMonitorTrafficThreshold', 0),
-		);
+		const icMonitorTrafficThreshold = this.instantConfig.get('icMonitorTrafficThreshold', {});
+		const monitorTrafficThreshold =
+			typeof icMonitorTrafficThreshold === 'number'
+				? { default: icMonitorTrafficThreshold }
+				: icMonitorTrafficThreshold;
+		Object.keys(monitorTrafficThreshold).forEach((key) => {
+			context.set(`services.monitoring-${key}.threshold`, monitorTrafficThreshold[key]);
+		});
 	}
 }

--- a/src/platforms/shared/tracking/metric-reporter.ts
+++ b/src/platforms/shared/tracking/metric-reporter.ts
@@ -27,7 +27,7 @@ export class MetricReporter {
 	private slotTimeDiffRequestToRender = new Map<string, number>();
 
 	constructor() {
-		this.isActive = utils.outboundTrafficRestrict.isOutboundTrafficAllowed('monitoring');
+		this.isActive = utils.outboundTrafficRestrict.isOutboundTrafficAllowed('monitoring-default');
 	}
 
 	execute() {


### PR DESCRIPTION
### Links
https://fandom.atlassian.net/browse/ADEN-13294

### Description
[icMonitorTrafficThreshold](https://services.fandom.com/icbm/dashboard/feature_flag/icMonitorTrafficThreshold) is a great variable, but for now it had a very simple format (integer). While implementing some of the reporting logic in IdentityEngine, I wanted to use the same ICBM variable to control sampling, but I would like to manage percentages and geos in Identity monitoring independent of AdEngine monitoring settings. That's why the ICBM variable will be moving from integer to JSON object with more complex format.
This PR provides a backward compatible implementation to AdEngine, so it will be able to handle icMonitorTrafficThreshold being both integer and JSON object.