### PR TITLE
ADEN-13300 Send IntentIQ report on adRenderSucceeded event

### DIFF
--- a/spec/ad-bidders/prebid/intent-iq/intent-iq.spec.ts
+++ b/spec/ad-bidders/prebid/intent-iq/intent-iq.spec.ts
@@ -78,7 +78,7 @@ describe('IntentIQ', () => {
 			global.sandbox.stub(context, 'get').withArgs('bidders.prebid.intentIQ').returns(false);
 			const intentIQ = new IntentIQ();
 
-			await intentIQ.reportPrebidWin('top_leaderboard');
+			await intentIQ.reportPrebidWin({} as PrebidBidResponse);
 
 			expect(intentIqReportSpy.notCalled).to.be.true;
 		});
@@ -91,29 +91,24 @@ describe('IntentIQ', () => {
 				.withArgs('options.trackingOptIn')
 				.returns(true);
 
-			pbjsStub.getBidResponsesForAdUnitCode.returns({
-				bids: [
-					PrebidBidFactory.getBid({
-						adId: 'ad-123',
-						bidderCode: 'appnexus',
-						auctionId: '1234-5678',
-						cpm: 0.12,
-						currency: 'USD',
-						originalCpm: 0.12,
-						originalCurrency: 'USD',
-						adUnitCode: 'top_leaderboard',
-						adserverTargeting: { hb_adid: 'ad-123', hb_pb: '0.12' },
-					}),
-				],
+			const bid = PrebidBidFactory.getBid({
+				adId: 'ad-123',
+				bidderCode: 'appnexus',
+				auctionId: '1234-5678',
+				cpm: 0.12,
+				currency: 'USD',
+				originalCpm: 0.12,
+				originalCurrency: 'USD',
+				adUnitCode: 'top_leaderboard',
+				adserverTargeting: { hb_adid: 'ad-123', hb_pb: '0.12' },
 			});
 
 			const intentIQ = new IntentIQ();
 			await intentIQ.initialize(pbjsStub);
 
-			await intentIQ.reportPrebidWin('top_leaderboard');
+			await intentIQ.reportPrebidWin(bid);
 
 			expect(intentIqNewSpy.calledOnce).to.be.true;
-			expect(pbjsStub.getBidResponsesForAdUnitCode.called).to.be.true;
 			expect(
 				intentIqReportSpy.calledOnceWithExactly({
 					biddingPlatformId: 1,

--- a/src/ad-bidders/prebid/index.ts
+++ b/src/ad-bidders/prebid/index.ts
@@ -269,6 +269,11 @@ export class PrebidProvider extends BidderProvider {
 		};
 
 		pbjs.onEvent('bidResponse', trackBid);
+		pbjs.onEvent(
+			'adRenderSucceeded',
+			(response: { adId: string; bid: PrebidBidResponse; doc: Document | null }) =>
+				intentIQ.reportPrebidWin(response.bid),
+		);
 	}
 
 	private mapResponseToTrackingBidDefinition(response: PrebidBidResponse): TrackingBidDefinition {

--- a/src/ad-bidders/prebid/intent-iq/intent-iq.ts
+++ b/src/ad-bidders/prebid/intent-iq/intent-iq.ts
@@ -5,7 +5,6 @@ import {
 	targetingService,
 	utils,
 } from '@ad-engine/core';
-import { getBidByAdId, getWinningBid } from '../prebid-helper';
 
 const logGroup = 'IntentIQ';
 
@@ -69,32 +68,21 @@ export class IntentIQ {
 		}
 	}
 
-	async reportPrebidWin(slotName: string): Promise<void> {
+	async reportPrebidWin(bid: PrebidBidResponse): Promise<void> {
 		if (!this.isEnabled() || !this.intentIqObject) {
-			return;
-		}
-
-		const slotAlias = context.get(`slots.${slotName}.bidderAlias`) || slotName;
-		const winningBid = await getWinningBid(slotAlias);
-		if (Object.keys(winningBid).length === 0) {
-			return;
-		}
-
-		const winningBidResponse = await getBidByAdId(slotAlias, winningBid.hb_adid);
-		if (!winningBidResponse) {
 			return;
 		}
 
 		const data: IntentIQReportData = {
 			biddingPlatformId: 1, // Prebid
-			bidderCode: winningBidResponse.bidderCode,
-			prebidAuctionId: winningBidResponse.auctionId,
-			cpm: winningBidResponse.cpm,
-			currency: winningBidResponse.currency,
-			originalCpm: winningBidResponse.originalCpm,
-			originalCurrency: winningBidResponse.originalCurrency,
-			status: winningBidResponse.status,
-			placementId: winningBidResponse.adUnitCode,
+			bidderCode: bid.bidderCode,
+			prebidAuctionId: bid.auctionId,
+			cpm: bid.cpm,
+			currency: bid.currency,
+			originalCpm: bid.originalCpm,
+			originalCurrency: bid.originalCurrency,
+			status: bid.status,
+			placementId: bid.adUnitCode,
 		};
 
 		utils.logger(logGroup, 'reporting prebid win', data);

--- a/src/ad-tracking/slot-tracker.ts
+++ b/src/ad-tracking/slot-tracker.ts
@@ -1,6 +1,5 @@
 import { communicationService } from '@ad-engine/communication';
 import { AdSlotEvent, AdSlotStatus } from '@ad-engine/core';
-import { intentIQ } from '../ad-bidders';
 import { BaseTracker, BaseTrackerInterface } from './base-tracker';
 import {
 	pageTrackingCompiler,
@@ -39,14 +38,6 @@ class SlotTracker extends BaseTracker implements BaseTrackerInterface {
 
 		communicationService.onSlotEvent(AdSlotEvent.SLOT_RENDERED_EVENT, ({ slot }) => {
 			slot.trackStatusAfterRendered = true;
-		});
-
-		communicationService.onSlotEvent(AdSlotEvent.SLOT_VIEWED_EVENT, async ({ slot }) => {
-			if (slot.winningBidderDetails === null) {
-				return;
-			}
-
-			intentIQ.reportPrebidWin(slot.getSlotName());
 		});
 
 		communicationService.onSlotEvent(AdSlotEvent.SLOT_STATUS_CHANGED, async ({ slot }) => {


### PR DESCRIPTION
### Links
https://fandom.atlassian.net/browse/ADEN-13281
https://fandom.atlassian.net/browse/ADEN-13300

### Description
We are trying to find best possible way to send IntentIQ report data in a consistent manner, so the data from GAM reports is more or less the same. After previous fixes (introduced by #1975) data from both sources got very close, but still not close enough.
This is yet another, and probably the best way to send report to IntentIQ only when prebid ad is rendered to the end user. It uses `adRenderSucceeded` [1] event, which seems to be the best source of truth that we can get for such a case.

<hr>

[[1] Prebid Events documentation](https://docs.prebid.org/dev-docs/publisher-api-reference/getEvents.html)