### PR TITLE
ADEN-13299 - Fixed tracking Identity

### DIFF
--- a/src/platforms/shared/tracking/tracking.setup.ts
+++ b/src/platforms/shared/tracking/tracking.setup.ts
@@ -47,8 +47,25 @@ export class TrackingSetup {
 		this.interventionTracker();
 		this.adClickTracker();
 		this.ctaTracker();
+		this.identityTracker();
 		this.keyValsTracker();
 		this.adSizeTracker.init();
+	}
+
+	private identityTracker(): void {
+		communicationService.on(
+			eventsRepository.IDENTITY_PARTNER_DATA_OBTAINED,
+			(eventInfo) => {
+				this.dwTracker.track(
+					{
+						partner_name: eventInfo.payload.partnerName,
+						partner_identity_id: eventInfo.payload.partnerIdentityId,
+					},
+					trackingUrls.IDENTITY_INFO,
+				);
+			},
+			false,
+		);
 	}
 
 	private porvataTracker(): void {


### PR DESCRIPTION
In recent migration revert, we missed one file. It was found when we ( me and @JackThePie ) were analysing what is going on with our HEMs. 
https://github.com/Wikia/ad-engine/commit/5f1d31eb8c72ca5cc29e00b3c4cb2f1330b16d4a#diff-93a8db8182c3455559133794f9780d2c72dc6ca8b279568e4d10a105beb12aba
vs 
 https://github.com/Wikia/ad-engine/commit/1a68cf679cf5431a049316965e98d154d749ffbf

Showing 24 changed files with 10 additions and 1,047 deletions.
vs
Showing 23 changed files with 1,030 additions and 10 deletions.

 we can clearly see that one file was not reverted. In this PR I've fixed that.