### PR TITLE
ADEN-13291 Adjust IIQ A/B groups %

### DIFF
--- a/spec/ad-bidders/prebid/intent-iq/intent-iq.spec.ts
+++ b/spec/ad-bidders/prebid/intent-iq/intent-iq.spec.ts
@@ -64,7 +64,7 @@ describe('IntentIQ', () => {
 					pbjs: pbjsStub,
 					timeoutInMillis: DEFAULT_MAX_DELAY,
 					ABTestingConfigurationSource: 'percentage',
-					abPercentage: 90,
+					abPercentage: 97,
 					manualWinReportEnabled: true,
 					browserBlackList: 'Chrome',
 				}),

--- a/src/ad-bidders/prebid/intent-iq/intent-iq.ts
+++ b/src/ad-bidders/prebid/intent-iq/intent-iq.ts
@@ -51,7 +51,7 @@ export class IntentIQ {
 					pbjs,
 					timeoutInMillis: DEFAULT_MAX_DELAY,
 					ABTestingConfigurationSource: 'percentage',
-					abPercentage: 90,
+					abPercentage: 97,
 					manualWinReportEnabled: true,
 					browserBlackList: 'Chrome',
 					domainName,


### PR DESCRIPTION
### Links
https://fandom.atlassian.net/browse/ADEN-13291

### Description
Right now 10% of traffic that uses IntentIQ is used as a control group. It also means that 10% of traffic is not enhanced by IntentIQ and is providing worse eCPM than remaining 90%. As we want to serve more ads via IntentIQ 97% was established with IntentIQ as a compromise, so there is still enough control group data (but if it all works well we may try 99% vs 1% at some point).