### PR TITLE
ADEN-13340 Call LiveConnect resolve method once instead multiple times

### DIFF
--- a/@types/live-connect/index.d.ts
+++ b/@types/live-connect/index.d.ts
@@ -8,5 +8,7 @@ interface LiQ {
 
 interface LiQParams {
 	qf: string;
-	resolve: 'sha1' | 'sha2' | 'md5';
+	resolve: LiQResolveParams[];
 }
+
+type LiQResolveParams = 'sha1' | 'sha2' | 'md5' | 'unifiedId';


### PR DESCRIPTION
### Ticket
https://fandom.atlassian.net/browse/ADEN-13340

### Description
It was recommended to us by LiveConnect to call their `window.LiQ.resolve()` method once instead of multiple times.
It can be done by calling this method with array of parameters we want to resolve, so: `["sha1", "sha2", "md5", "unifiedId"]`