### PR TITLE
ADEN-13453 Workaround for lack of tlb and floor adhesion issue

### DIFF
--- a/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-dynamic-slots.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-dynamic-slots.setup.ts
@@ -61,6 +61,7 @@ export class NewsAndRatingsDynamicSlotsSetup implements DiProcess {
 
 		if (!tlbExists) {
 			communicationService.on(eventsRepository.AD_ENGINE_STACK_START, () => {
+				context.set(`slots.top_leaderboard.defaultTemplates`, []);
 				btfBlockerService.finishFirstCall();
 				communicationService.emit(eventsRepository.AD_ENGINE_UAP_LOAD_STATUS, {
 					isLoaded: universalAdPackage.isFanTakeoverLoaded(),


### PR DESCRIPTION
The issue with floor adhesion is caused by lack of tlb, because we are waiting for STICKINESS_DISABLED event from the tlb to inject floor adhesion, but we haven't got tlb, so the event won't be emitted. That's workaround for setting empty template for tlb, if tlb is not exisiting on N&R sites.