### PR TITLE
TACO-106 - Added additional tracking event

### DIFF
--- a/src/ad-bidders/a9/index.ts
+++ b/src/ad-bidders/a9/index.ts
@@ -13,6 +13,7 @@ import {
 	SlotConfig,
 	slotService,
 	targetingService,
+	trackingOptIn,
 	Usp,
 	usp,
 	utils,
@@ -125,6 +126,12 @@ export class A9Provider extends BidderProvider {
 			}
 
 			this.apstag.init(this.getApstagConfig(signalData));
+
+			if (!trackingOptIn.isOptedIn() || trackingOptIn.isOptOutSale()) {
+				utils.logger(logGroup, 'A9 was initialized without consents');
+				communicationService.emit(eventsRepository.A9_WITHOUT_CONSENTS);
+			}
+
 			this.loaded = true;
 		}
 	}

--- a/src/communication/event-types.ts
+++ b/src/communication/event-types.ts
@@ -188,6 +188,9 @@ export const eventsRepository: Dictionary<EventOptions> = {
 	EYEOTA_FAILED: {
 		name: 'Eyeota loading failed',
 	},
+	A9_WITHOUT_CONSENTS: {
+		name: 'A9 without consents',
+	},
 	IDENTITY_ENGINE_READY: {
 		category: '[IdentityEngine]',
 		name: 'Identity ready',

--- a/src/communication/event-types.ts
+++ b/src/communication/event-types.ts
@@ -188,9 +188,6 @@ export const eventsRepository: Dictionary<EventOptions> = {
 	EYEOTA_FAILED: {
 		name: 'Eyeota loading failed',
 	},
-	A9_WITHOUT_CONSENTS: {
-		name: 'A9 without consents',
-	},
 	IDENTITY_ENGINE_READY: {
 		category: '[IdentityEngine]',
 		name: 'Identity ready',
@@ -297,6 +294,9 @@ export const eventsRepository: Dictionary<EventOptions> = {
 		name: 'Ready',
 	},
 	// Bidders events //
+	A9_WITHOUT_CONSENTS: {
+		name: 'A9 without consents',
+	},
 	BIDDERS_BIDDING_DONE: {
 		category: '[Prebid]',
 		name: 'Bidding done',

--- a/src/platforms/shared/tracking/load-times-tracker.ts
+++ b/src/platforms/shared/tracking/load-times-tracker.ts
@@ -16,6 +16,7 @@ const eventsToTrack = {
 	captify_loaded: eventsRepository.CAPTIFY_LOADED,
 	eyeota_started: eventsRepository.EYEOTA_STARTED,
 	eyeota_failed: eventsRepository.EYEOTA_FAILED,
+	a9_without_consents: eventsRepository.A9_WITHOUT_CONSENTS,
 	intentiq_ppid_not_set_on_time: eventsRepository.INTENTIQ_PPID_NOT_SET_ON_TIME,
 };
 


### PR DESCRIPTION
In this PR I've added an additional event that will be sent to our DWH. This way we want to track % of A9 bids that does not have consent and estimate % of events that might be invalid.