### PR TITLE
TACO-136 IIQ Additional targeting key val

### DIFF
--- a/spec/ad-bidders/prebid/intent-iq/intent-iq.spec.ts
+++ b/spec/ad-bidders/prebid/intent-iq/intent-iq.spec.ts
@@ -93,7 +93,8 @@ describe('IntentIQ', () => {
 					browserBlackList: 'Chrome',
 				}),
 			).to.be.true;
-			expect(targetingServiceStub.calledOnceWithExactly('intent_iq_group', 'A')).to.be.true;
+			expect(targetingServiceStub.calledWithExactly('intent_iq_group', 'A')).to.be.true;
+			expect(targetingServiceStub.calledWithExactly('intent_iq_ppid_group', 'A')).to.be.true;
 		});
 	});
 

--- a/src/ad-bidders/prebid/intent-iq/intent-iq.ts
+++ b/src/ad-bidders/prebid/intent-iq/intent-iq.ts
@@ -73,6 +73,10 @@ export class IntentIQ {
 					'intent_iq_group',
 					this.intentIqObject.intentIqConfig.abTesting.currentTestGroup || 'U',
 				);
+				targetingService.set(
+					'intent_iq_ppid_group',
+					this.intentIqObject.intentIqConfig.abTesting.currentTestGroup || 'U',
+				);
 			});
 		}
 	}


### PR DESCRIPTION
### Ticket
https://fandom.atlassian.net/browse/TACO-136

### Description
Add additional targeting key value `intent_iq_ppid_group` with a copy of the same info (A/B/U) the `intent_iq_group` key-val carries