### PR TITLE
TACO-36 - Adjusted Ozone config

### DIFF
--- a/src/ad-bidders/prebid/adapters/ozone.ts
+++ b/src/ad-bidders/prebid/adapters/ozone.ts
@@ -44,7 +44,6 @@ export class Ozone extends PrebidAdapter {
 							{
 								settings: {},
 								targeting: {
-									page_type: 'article',
 									...this.getTargeting(code, this.customTargeting),
 								},
 							},

--- a/src/ad-bidders/prebid/adapters/ozone.ts
+++ b/src/ad-bidders/prebid/adapters/ozone.ts
@@ -1,11 +1,22 @@
+import { context, Dictionary, targetingService } from '@ad-engine/core';
 import { PrebidAdapter } from '../prebid-adapter';
+import { PrebidAdSlotConfig } from '../prebid-models';
 
 export class Ozone extends PrebidAdapter {
 	static bidderName = 'ozone';
 	dcn: string;
+	customTargeting: Dictionary;
 
 	constructor(options) {
 		super(options);
+		this.customTargeting = {
+			s1: [
+				context.get('wiki.targeting.wikiIsTop1000')
+					? targetingService.get('s1') || ''
+					: 'not a top1k wiki',
+			],
+			lang: [targetingService.get('wikiLanguage') || targetingService.get('lang') || 'en'],
+		};
 		this.dcn = options.dcn;
 	}
 
@@ -13,7 +24,7 @@ export class Ozone extends PrebidAdapter {
 		return Ozone.bidderName;
 	}
 
-	prepareConfigForAdUnit(code, { sizes, pos }): PrebidAdUnit {
+	prepareConfigForAdUnit(code, { sizes, pos }: PrebidAdSlotConfig): PrebidAdUnit {
 		return {
 			code: code,
 			mediaTypes: {
@@ -27,8 +38,17 @@ export class Ozone extends PrebidAdapter {
 					params: {
 						publisherId: 'OZONETEST001',
 						siteId: '4204204201',
-						placementId: '0420420421',
+						placementId: '8000000326',
 						pos,
+						customData: [
+							{
+								settings: {},
+								targeting: {
+									page_type: 'article',
+									...this.getTargeting(code, this.customTargeting),
+								},
+							},
+						],
 					},
 				},
 			],


### PR DESCRIPTION
In this PR I've added additional config for Ozone bidder. It should use similar targeting values as our other bidders, and should use testing IDs for now.