### PR TITLE
ADEN-13593 Anyclip after first header

### DIFF
--- a/src/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-slots-definition-repository.ts
+++ b/src/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-slots-definition-repository.ts
@@ -283,7 +283,7 @@ export class UcpMobileSlotsDefinitionRepository {
 
 		const slotName = 'incontent_player';
 		const controlledSectionId = document
-			.querySelector('.mw-parser-output > h2:nth-of-type(1)')
+			.querySelector('.mw-parser-output > h2:first-of-type')
 			?.getAttribute('aria-controls');
 
 		return {

--- a/src/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-slots-definition-repository.ts
+++ b/src/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-slots-definition-repository.ts
@@ -284,7 +284,7 @@ export class UcpMobileSlotsDefinitionRepository {
 		const slotName = 'incontent_player';
 		const controlledSectionId = document
 			.querySelector('.mw-parser-output > h2:nth-of-type(1)')
-			.getAttribute('aria-controls');
+			?.getAttribute('aria-controls');
 
 		return {
 			slotCreatorConfig: {

--- a/src/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-slots-definition-repository.ts
+++ b/src/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-slots-definition-repository.ts
@@ -282,14 +282,17 @@ export class UcpMobileSlotsDefinitionRepository {
 		}
 
 		const slotName = 'incontent_player';
+		const controlledSectionId = document
+			.querySelector('.mw-parser-output > h2:nth-of-type(1)')
+			.getAttribute('aria-controls');
 
 		return {
 			slotCreatorConfig: {
 				slotName,
-				anchorSelector: '.incontent-boxad',
-				anchorPosition: 'belowScrollPosition',
+				anchorSelector: `#${controlledSectionId}`,
+				anchorPosition: 'firstViable',
 				insertMethod: 'prepend',
-				avoidConflictWith: ['.ad-slot', '#incontent_boxad_1'],
+				avoidConflictWith: [],
 			},
 			activator: () => {
 				context.push('state.adStack', { id: slotName });


### PR DESCRIPTION
[JIRA ➡️ ADEN-13593](https://fandom.atlassian.net/browse/ADEN-13593)
- Changed anyclip anchor point to be rendered after first header.

**Note**:
Since UCP https://github.com/Wikia/unified-platform/blob/master/skins/FandomMobile/scripts/CollapsibleSections.ts#L14 contains the following bug (in my opinion) with collapsible elements. And appends hide/show logic to the `nextSibling` instead of element inside `aria-controls` attribute we can't just add anyclip block `after` header. The workaround which I use is to add it inside content section controlled by header. As side effect hide section = video close + if areas collapsed by default, we not gonna have this ad.

Other options are:
- fix UCP collapsible behaviour, but I believe we not want to do it since it could break a lot of things there
- place ad on top of header, which results in stacked ads



<details>
<summary>📷 Screenshots</summary>
<img width="315" alt="image" src="https://github.com/Wikia/ad-engine/assets/34650035/9bc2358c-3666-4aee-be4c-950da477192d">
<img width="315" alt="image" src="https://github.com/Wikia/ad-engine/assets/34650035/93e8fc85-375a-43bc-9622-bc37fe73d30a">
</details>
