### PR TITLE
Fix getServicesBaseURL util

### DIFF
--- a/src/core/utils/service-base-url.ts
+++ b/src/core/utils/service-base-url.ts
@@ -1,5 +1,19 @@
 export function getServicesBaseURL() {
-	return document.currentScript && 'src' in document.currentScript
-		? new URL(document.currentScript.src).origin + '/'
-		: 'https://services.fandom.com/';
+	const fandomDomains = [
+		'fandom.com',
+		'tvguide.com',
+		'metacritic.com',
+		'gamespot.com',
+		'giantbomb.com',
+		'muthead.com',
+		'futhead.com',
+		'fandom-ae-assets.s3.amazonaws.com',
+		'fanatical.com',
+	];
+
+	return fandomDomains.find((domain) => window.location.hostname.includes(domain))
+		? 'https://services.fandom.com/'
+		: 'https://services.fandom-dev.' +
+				(location.hostname.match(/(?!\.)(pl|us)$/) || ['us'])[0] +
+				'/';
 }

--- a/src/core/utils/service-base-url.ts
+++ b/src/core/utils/service-base-url.ts
@@ -1,9 +1,5 @@
 export function getServicesBaseURL() {
-	const fandomDomains = ['fandom.com', 'muthead.com', 'futhead.com'];
-
-	return fandomDomains.find((domain) => window.location.hostname.includes(domain))
-		? 'https://services.fandom.com/'
-		: 'https://services.fandom-dev.' +
-				(location.hostname.match(/(?!\.)(pl|us)$/) || ['us'])[0] +
-				'/';
+	return document.currentScript && 'src' in document.currentScript
+		? new URL(document.currentScript.src).origin + '/'
+		: 'https://services.fandom.com/';
 }


### PR DESCRIPTION
Uses [document.currentScript](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) property. It will return URL of loader script that has been included in the page.