### PR TITLE
COTECH-713 | Add Optimizely experiments to targeting

### DIFF
--- a/@types/window/index.d.ts
+++ b/@types/window/index.d.ts
@@ -60,4 +60,9 @@ interface Window {
 	utag_data?: any;
 	wgCookiePath?: string;
 	XMLHttpRequest?: any;
+	optimizely?: {
+		get?: (type: string) => {
+			getVariationMap: () => Record<string, { id: string; name: string }>;
+		};
+	};
 }

--- a/spec/platforms/shared/context/targeting/ucp-targeting.setup.spec.ts
+++ b/spec/platforms/shared/context/targeting/ucp-targeting.setup.spec.ts
@@ -1,0 +1,77 @@
+import { InstantConfigService, targetingService } from '@wikia/core';
+import { UcpTargetingSetup } from '@wikia/platforms/shared';
+import { expect } from 'chai';
+
+let instantConfigStub;
+
+beforeEach(() => {
+	instantConfigStub = global.sandbox.createStubInstance(InstantConfigService);
+});
+
+afterEach(() => {
+	delete window.optimizely;
+	targetingService.clear();
+});
+
+describe('UCPTargetingSetup', () => {
+	it('adds optimizely experiments to targeting', () => {
+		window.optimizely = {
+			get: () => ({
+				getVariationMap: () => ({
+					'123456789': {
+						id: '234567890',
+						name: 'test',
+					},
+				}),
+			}),
+		};
+		const ucpTargetingSetup = new UcpTargetingSetup(instantConfigStub);
+		ucpTargetingSetup.execute();
+
+		expect(targetingService.get('optimizely')).to.eql(['123456789_234567890']);
+	});
+
+	it('adds all optimizely experiments to targeting', () => {
+		window.optimizely = {
+			get: () => ({
+				getVariationMap: () => ({
+					'123456789': {
+						id: '234567890',
+						name: 'test',
+					},
+					'987654321': {
+						id: '876543210',
+						name: 'test2',
+					},
+				}),
+			}),
+		};
+
+		const ucpTargetingSetup = new UcpTargetingSetup(instantConfigStub);
+		ucpTargetingSetup.execute();
+
+		expect(targetingService.get('optimizely')).to.eql([
+			'123456789_234567890',
+			'987654321_876543210',
+		]);
+	});
+
+	it('do not add optimizely experiments to targeting when optimizely is not loaded', () => {
+		const ucpTargetingSetup = new UcpTargetingSetup(instantConfigStub);
+		ucpTargetingSetup.execute();
+
+		expect(targetingService.get('optimizely')).to.be.undefined;
+	});
+
+	it('do not add optimizely experiments to targeting when optimizely is loaded but getVariationMap return empty object', () => {
+		window.optimizely = {
+			get: () => ({
+				getVariationMap: () => ({}),
+			}),
+		};
+		const ucpTargetingSetup = new UcpTargetingSetup(instantConfigStub);
+		ucpTargetingSetup.execute();
+
+		expect(targetingService.get('optimizely')).to.be.undefined;
+	});
+});

--- a/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
+++ b/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
@@ -9,6 +9,7 @@ import {
 	utils,
 } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
+import { getOptimizelyActiveVariations } from '../../utils/optimizely';
 import { createFandomContext } from './targeting-strategies/factories/create-fandom-context';
 import { createOpenRtb2Context } from './targeting-strategies/factories/create-open-rtb2-context';
 import { createSelectedStrategy } from './targeting-strategies/factories/create-selected-strategy';
@@ -53,6 +54,18 @@ export class UcpTargetingSetup implements DiProcess {
 			'bundles',
 			utils.targeting.getTargetingBundles(this.instantConfig.get('icTargetingBundles')),
 		);
+
+		const optimizelyVariations = getOptimizelyActiveVariations();
+
+		if (optimizelyVariations) {
+			const optimizelyTargeting = Object.keys(optimizelyVariations).map((experimentId) => {
+				return `${experimentId}_${optimizelyVariations[experimentId].id}`;
+			});
+
+			if (optimizelyTargeting.length) {
+				targetingService.set('optimizely', optimizelyTargeting);
+			}
+		}
 
 		if (this.instantConfig.get<boolean>('icOpenRtb2Context')) {
 			targetingService.set('openrtb2', createOpenRtb2Context(fandomContext), 'openrtb2');

--- a/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
+++ b/src/platforms/shared/context/targeting/ucp-targeting.setup.ts
@@ -9,7 +9,7 @@ import {
 	utils,
 } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
-import { getOptimizelyActiveVariations } from '../../utils/optimizely';
+import { getOptimizelyTargeting } from '../../utils/optimizely';
 import { createFandomContext } from './targeting-strategies/factories/create-fandom-context';
 import { createOpenRtb2Context } from './targeting-strategies/factories/create-open-rtb2-context';
 import { createSelectedStrategy } from './targeting-strategies/factories/create-selected-strategy';
@@ -55,16 +55,10 @@ export class UcpTargetingSetup implements DiProcess {
 			utils.targeting.getTargetingBundles(this.instantConfig.get('icTargetingBundles')),
 		);
 
-		const optimizelyVariations = getOptimizelyActiveVariations();
+		const optimizelyTargeting = getOptimizelyTargeting();
 
-		if (optimizelyVariations) {
-			const optimizelyTargeting = Object.keys(optimizelyVariations).map((experimentId) => {
-				return `${experimentId}_${optimizelyVariations[experimentId].id}`;
-			});
-
-			if (optimizelyTargeting.length) {
-				targetingService.set('optimizely', optimizelyTargeting);
-			}
+		if (optimizelyTargeting.length) {
+			targetingService.set('optimizely', optimizelyTargeting);
 		}
 
 		if (this.instantConfig.get<boolean>('icOpenRtb2Context')) {

--- a/src/platforms/shared/utils/optimizely.ts
+++ b/src/platforms/shared/utils/optimizely.ts
@@ -1,0 +1,3 @@
+export const getOptimizelyActiveVariations = () => {
+	return window.optimizely?.get?.('state').getVariationMap();
+};

--- a/src/platforms/shared/utils/optimizely.ts
+++ b/src/platforms/shared/utils/optimizely.ts
@@ -1,3 +1,11 @@
 export const getOptimizelyActiveVariations = () => {
 	return window.optimizely?.get?.('state').getVariationMap();
 };
+
+export const getOptimizelyTargeting = () => {
+	const optimizelyVariations = getOptimizelyActiveVariations() ?? {};
+
+	return Object.keys(optimizelyVariations).map((experimentId) => {
+		return `${experimentId}_${optimizelyVariations[experimentId].id}`;
+	});
+};


### PR DESCRIPTION
we want to pass information about the active Optimizely experiment to GAM. As the experiments sometimes are implemented in different code bases we want to have the targeting set independently to avoid introducing unnecessary communication between the adengine and the experiment code just to inform that the experiment is active.