### PR TITLE
COTECH-765 | Anyclip updates for gamefaqs

### DIFF
--- a/spec/core/ad-engine.spec.ts
+++ b/spec/core/ad-engine.spec.ts
@@ -1,0 +1,22 @@
+import { communicationService, eventsRepository } from '@wikia/communication';
+import { AdEngine, AdStackPayload } from '@wikia/core';
+import { OldLazyQueue } from '@wikia/core/utils';
+import { expect } from 'chai';
+
+describe('AdEngine', () => {
+	it('emits AD_ENGINE_STACK_START and AD_ENGINE_STACK_COMPLETED events', async () => {
+		const adEngine = new AdEngine();
+		adEngine.adStack = {
+			start: () => {},
+		} as OldLazyQueue<AdStackPayload>;
+
+		const emitSpy = global.sandbox.spy(communicationService, 'emit');
+
+		adEngine.runAdQueue();
+
+		communicationService.emit(eventsRepository.AD_ENGINE_PARTNERS_READY);
+
+		expect(emitSpy.calledWith(eventsRepository.AD_ENGINE_STACK_START)).to.be.true;
+		expect(emitSpy.calledWith(eventsRepository.AD_ENGINE_STACK_COMPLETED)).to.be.true;
+	});
+});

--- a/spec/platforms/news-and-ratings/gamespot/setup/context/slots/gamefaqs-slots-definition-repository.spec.ts
+++ b/spec/platforms/news-and-ratings/gamespot/setup/context/slots/gamefaqs-slots-definition-repository.spec.ts
@@ -8,7 +8,7 @@ describe('GameFAQsSlotsDefinitionRepository', () => {
 
 		expect(repository.getIncontentPlayerConfig().slotCreatorConfig).to.deep.eq({
 			slotName: 'incontent_player',
-			anchorSelector: '.msg_body',
+			anchorSelector: '.msg_list .msg_body',
 			insertMethod: 'prepend',
 		});
 	});

--- a/spec/platforms/news-and-ratings/gamespot/setup/context/slots/gamefaqs-slots-definition-repository.spec.ts
+++ b/spec/platforms/news-and-ratings/gamespot/setup/context/slots/gamefaqs-slots-definition-repository.spec.ts
@@ -1,0 +1,23 @@
+import { context } from '@wikia/core';
+import { GameFAQsSlotsDefinitionRepository } from '@wikia/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-slots-definition-repository';
+import { expect } from 'chai';
+
+describe('GameFAQsSlotsDefinitionRepository', () => {
+	it('should return proper slot creator config', () => {
+		const repository = new GameFAQsSlotsDefinitionRepository();
+
+		expect(repository.getIncontentPlayerConfig().slotCreatorConfig).to.deep.eq({
+			slotName: 'incontent_player',
+			anchorSelector: '.msg_body',
+			insertMethod: 'prepend',
+		});
+	});
+
+	it('should return proper activator', () => {
+		const repository = new GameFAQsSlotsDefinitionRepository();
+
+		repository.getIncontentPlayerConfig().activator();
+
+		expect(context.get('state.adStack')).to.deep.contain({ id: 'incontent_player' });
+	});
+});

--- a/src/communication/event-types.ts
+++ b/src/communication/event-types.ts
@@ -114,6 +114,9 @@ export const eventsRepository: Dictionary<EventOptions> = {
 	AD_ENGINE_STACK_START: {
 		name: 'Ad Stack started',
 	},
+	AD_ENGINE_STACK_COMPLETED: {
+		name: 'Ad Stack completed',
+	},
 	AD_ENGINE_TEMPLATE_LOADED: {
 		name: 'Template loaded',
 		payload: props<GeneralPayload>(),

--- a/src/communication/event-types.ts
+++ b/src/communication/event-types.ts
@@ -77,7 +77,7 @@ export interface IdentityDataPayload {
 	partnerIdentityId: string | null;
 }
 
-export const eventsRepository: Dictionary<EventOptions> = {
+export const eventsRepository = {
 	// AdEngine life cycle events //
 	AD_ENGINE_BAB_DETECTION: {
 		category: '[Ad Engine]',
@@ -381,4 +381,4 @@ export const eventsRepository: Dictionary<EventOptions> = {
 		name: 'Load template',
 		payload: payload<LoadTemplatePayload>(),
 	},
-};
+} as const satisfies Dictionary<EventOptions>;

--- a/src/core/ad-engine.ts
+++ b/src/core/ad-engine.ts
@@ -134,9 +134,10 @@ export class AdEngine {
 		communicationService.on(eventsRepository.AD_ENGINE_PARTNERS_READY, () => {
 			if (!this.started) {
 				communicationService.emit(eventsRepository.AD_ENGINE_STACK_START);
-
 				this.started = true;
 				this.adStack.start();
+
+				communicationService.emit(eventsRepository.AD_ENGINE_STACK_COMPLETED);
 			}
 		});
 	}

--- a/src/platforms/news-and-ratings/gamefaqs/ad-context.ts
+++ b/src/platforms/news-and-ratings/gamefaqs/ad-context.ts
@@ -33,11 +33,9 @@ export const basicContext = {
 	},
 	services: {
 		anyclip: {
-			enabled: false,
 			pubname: '1999',
-			miniPlayerWidgetname: '001w000001Y8ud2AAB_M7309',
-			libraryUrl: '//player.anyclip.com/anyclip-widget/lre-widget/prod/v1/src/acins.js',
-			loadWithoutAnchor: true,
+			widgetname: '001w000001Y8ud2AAB_M7731',
+			libraryUrl: '//player.anyclip.com/anyclip-widget/lre-widget/prod/v1/src/lre.js',
 		},
 		doubleVerify: {
 			slots: ['mpu_top', 'top_leaderboard'],

--- a/src/platforms/news-and-ratings/gamefaqs/gamefaqs-platform.ts
+++ b/src/platforms/news-and-ratings/gamefaqs/gamefaqs-platform.ts
@@ -14,7 +14,6 @@ import { SlotsConfigurationExtender } from '../../shared/setup/slots-config-exte
 import {
 	BiddersStateOverwriteSetup,
 	NewsAndRatingsAdsMode,
-	NewsAndRatingsAnyclipSetup,
 	NewsAndRatingsBaseContextSetup,
 	NewsAndRatingsDynamicSlotsSetup,
 	NewsAndRatingsTargetingSetup,
@@ -23,6 +22,7 @@ import {
 import { basicContext } from './ad-context';
 import { GamefaqsA9ConfigSetup } from './setup/context/a9/gamefaqs-a9-config.setup';
 import { GamefaqsPrebidConfigSetup } from './setup/context/prebid/gamefaqs-prebid-config.setup';
+import { GameFAQsAnyclipSetup } from './setup/context/slots/gamefaqs-anyclip.setup';
 import { GamefaqsSlotsContextSetup } from './setup/context/slots/gamefaqs-slots-context.setup';
 import { GamefaqsTargetingSetup } from './setup/context/targeting/gamefaqs-targeting.setup';
 import { GamefaqsTemplatesSetup } from './templates/gamefaqs-templates.setup';
@@ -49,7 +49,7 @@ export class GamefaqsPlatform {
 			LoadTimesSetup,
 			GamefaqsSlotsContextSetup,
 			SlotsConfigurationExtender,
-			NewsAndRatingsAnyclipSetup,
+			GameFAQsAnyclipSetup,
 			NewsAndRatingsDynamicSlotsSetup,
 			GamefaqsPrebidConfigSetup,
 			GamefaqsA9ConfigSetup,

--- a/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-anyclip.setup.ts
+++ b/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-anyclip.setup.ts
@@ -1,0 +1,18 @@
+import { insertSlots } from '@platforms/shared';
+import { context, DiProcess } from '@wikia/ad-engine';
+import { Injectable } from '@wikia/dependency-injection';
+import { GameFAQsSlotsDefinitionRepository } from './gamefaqs-slots-definition-repository';
+
+@Injectable()
+export class GameFAQsAnyclipSetup implements DiProcess {
+	constructor(private slotsDefinitionRepository: GameFAQsSlotsDefinitionRepository) {}
+
+	execute(): void {
+		context.set('custom.hasIncontentPlayer', !!document.querySelector('.msg_body'));
+
+		// TODO: this line can be removed after releasing gamefaqs change that removes the element from the page
+		document.querySelector('.message_mpu')?.remove();
+
+		insertSlots([this.slotsDefinitionRepository.getIncontentPlayerConfig()]);
+	}
+}

--- a/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-anyclip.setup.ts
+++ b/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-anyclip.setup.ts
@@ -8,11 +8,14 @@ export class GameFAQsAnyclipSetup implements DiProcess {
 	constructor(private slotsDefinitionRepository: GameFAQsSlotsDefinitionRepository) {}
 
 	execute(): void {
-		context.set('custom.hasIncontentPlayer', !!document.querySelector('.msg_body'));
+		const incontentPlayerConfig = this.slotsDefinitionRepository.getIncontentPlayerConfig();
 
+		context.set(
+			'custom.hasIncontentPlayer',
+			!!document.querySelector(incontentPlayerConfig.slotCreatorConfig.anchorSelector),
+		);
 		// TODO: this line can be removed after releasing gamefaqs change that removes the element from the page
 		document.querySelector('.message_mpu')?.remove();
-
-		insertSlots([this.slotsDefinitionRepository.getIncontentPlayerConfig()]);
+		insertSlots([incontentPlayerConfig]);
 	}
 }

--- a/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-slots-definition-repository.ts
+++ b/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-slots-definition-repository.ts
@@ -1,0 +1,21 @@
+import { SlotSetupDefinition } from '@platforms/shared';
+import { context } from '@wikia/ad-engine';
+import { Injectable } from '@wikia/dependency-injection';
+
+@Injectable()
+export class GameFAQsSlotsDefinitionRepository {
+	getIncontentPlayerConfig(): SlotSetupDefinition {
+		const slotName = 'incontent_player';
+
+		return {
+			slotCreatorConfig: {
+				slotName,
+				anchorSelector: '.msg_body',
+				insertMethod: 'prepend',
+			},
+			activator: () => {
+				context.push('state.adStack', { id: slotName });
+			},
+		};
+	}
+}

--- a/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-slots-definition-repository.ts
+++ b/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-slots-definition-repository.ts
@@ -10,7 +10,7 @@ export class GameFAQsSlotsDefinitionRepository {
 		return {
 			slotCreatorConfig: {
 				slotName,
-				anchorSelector: '.msg_body',
+				anchorSelector: '.msg_list .msg_body',
 				insertMethod: 'prepend',
 			},
 			activator: () => {

--- a/src/platforms/news-and-ratings/gamefaqs/styles.scss
+++ b/src/platforms/news-and-ratings/gamefaqs/styles.scss
@@ -25,3 +25,10 @@ body {
 }
 
 @include out-of-page-styles();
+
+#incontent_player {
+	display: block;
+	float: right;
+	margin: 0 0 15px 8px;
+	width: 300px;
+}

--- a/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-anyclip.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-anyclip.setup.ts
@@ -29,11 +29,8 @@ export class NewsAndRatingsAnyclipSetup implements DiProcess {
 			const doesAnyclipTagExist = context.get('services.anyclip.anyclipTagExists');
 			const pathname = window.location.pathname.toLowerCase();
 
-			const isApplicable = doesAnyclipTagExist
-				? doesAnyclipTagExist
-				: this.isApplicable(pname)
-				? this.isApplicable(pname)
-				: this.isApplicable(pathname);
+			const isApplicable =
+				doesAnyclipTagExist || this.isApplicable(pname) || this.isApplicable(pathname);
 
 			utils.logger(this.logGroup, 'isApplicable: ', isApplicable, pname, pathname);
 

--- a/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-dynamic-slots.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-dynamic-slots.setup.ts
@@ -62,7 +62,7 @@ export class NewsAndRatingsDynamicSlotsSetup implements DiProcess {
 		context.set('state.topLeaderboardExists', tlbExists);
 
 		if (!tlbExists) {
-			communicationService.on(eventsRepository.AD_ENGINE_STACK_START, () => {
+			communicationService.on(eventsRepository.AD_ENGINE_STACK_COMPLETED, () => {
 				btfBlockerService.finishFirstCall();
 				communicationService.emit(eventsRepository.AD_ENGINE_UAP_LOAD_STATUS, {
 					isLoaded: universalAdPackage.isFanTakeoverLoaded(),


### PR DESCRIPTION
The idea is to use the same approach for anyclip as we use in FCP. So the player container is added by adengine using `slotCreatorConfig`. This way we will be less dependant on gamefaqs repo and we will be able to make changes in anyclip for gamefaqs just in adegine repo