### PR TITLE
ADEN-13681 TACO-176 Create Amazon Token from HEM

### DIFF
--- a/@types/apstag/index.d.ts
+++ b/@types/apstag/index.d.ts
@@ -1,6 +1,7 @@
 interface Apstag {
 	_Q: any[];
 	init?: (...args: any[]) => unknown;
+	rpa?: (...args: any[]) => void;
 	fetchBids?: (...args: any[]) => unknown;
 	targetingKeys?: () => string[];
 	debug?: (cmd: 'enable' | 'disable') => void;

--- a/spec/ad-bidders/a9/a9.spec.ts
+++ b/spec/ad-bidders/a9/a9.spec.ts
@@ -114,7 +114,7 @@ describe('A9Provider', () => {
 		});
 	});
 
-	describe('init', () => {
+	describe('call', () => {
 		let apstagInitStub: SinonStub;
 		let apstagFetchBids: SinonStub;
 
@@ -133,16 +133,12 @@ describe('A9Provider', () => {
 		it('should initialize Apstag with config and fetch bids', () => {
 			const a9 = new A9Provider(bidderConfig);
 
-			a9.init();
+			a9.call();
 
-			expect(
-				apstagInitStub.calledOnceWithExactly({
-					pubID: bidderConfig.amazonId,
-					videoAdServer: 'DFP',
-					deals: true,
-					signals: { ortb2: {} },
-				}),
-			).to.equal(true, 'init called with wrong arguments');
+			expect(apstagInitStub.calledOnceWithExactly()).to.equal(
+				true,
+				'init called with wrong arguments',
+			);
 			expect(
 				apstagFetchBids.calledOnceWithExactly({
 					slots: a9.getA9SlotsDefinitions(Object.keys(bidderConfig.slots)),
@@ -154,17 +150,12 @@ describe('A9Provider', () => {
 		it('should initialize Apstag with CCPA config and fetch bids', () => {
 			const a9 = new A9Provider(bidderConfig);
 
-			a9.init({ uspString: '1---' });
+			a9.call();
 
-			expect(
-				apstagInitStub.calledOnceWithExactly({
-					pubID: bidderConfig.amazonId,
-					videoAdServer: 'DFP',
-					deals: true,
-					params: { us_privacy: '1---' },
-					signals: { ortb2: {} },
-				}),
-			).to.equal(true, 'init called with wrong arguments');
+			expect(apstagInitStub.calledOnceWithExactly()).to.equal(
+				true,
+				'init called with wrong arguments',
+			);
 			expect(
 				apstagFetchBids.calledOnceWithExactly({
 					slots: a9.getA9SlotsDefinitions(Object.keys(bidderConfig.slots)),

--- a/spec/ad-bidders/a9/a9.spec.ts
+++ b/spec/ad-bidders/a9/a9.spec.ts
@@ -130,7 +130,7 @@ describe('A9Provider', () => {
 			targetingService.set('openrtb2', {}, 'openrtb2');
 		});
 
-		it('should initialize Apstag with config and fetch bids', () => {
+		it('should initialize Apstag with config and fetch bids', (done) => {
 			const a9 = new A9Provider(bidderConfig);
 
 			a9.call();
@@ -139,15 +139,19 @@ describe('A9Provider', () => {
 				true,
 				'init called with wrong arguments',
 			);
-			expect(
-				apstagFetchBids.calledOnceWithExactly({
-					slots: a9.getA9SlotsDefinitions(Object.keys(bidderConfig.slots)),
-					timeout: DEFAULT_MAX_DELAY,
-				}),
-			).to.equal(true, 'fetchBids called with wrong arguments');
+			// use setTimeout so underlying promise can be resolved
+			setTimeout(() => {
+				expect(
+					apstagFetchBids.calledOnceWithExactly({
+						slots: a9.getA9SlotsDefinitions(Object.keys(bidderConfig.slots)),
+						timeout: DEFAULT_MAX_DELAY,
+					}),
+				).to.equal(true, 'fetchBids called with wrong arguments');
+				done();
+			});
 		});
 
-		it('should initialize Apstag with CCPA config and fetch bids', () => {
+		it('should initialize Apstag with CCPA config and fetch bids', (done) => {
 			const a9 = new A9Provider(bidderConfig);
 
 			a9.call();
@@ -156,12 +160,16 @@ describe('A9Provider', () => {
 				true,
 				'init called with wrong arguments',
 			);
-			expect(
-				apstagFetchBids.calledOnceWithExactly({
-					slots: a9.getA9SlotsDefinitions(Object.keys(bidderConfig.slots)),
-					timeout: DEFAULT_MAX_DELAY,
-				}),
-			).to.equal(true, 'fetchBids called with wrong arguments');
+			// use setTimeout so underlying promise can be resolved
+			setTimeout(() => {
+				expect(
+					apstagFetchBids.calledOnceWithExactly({
+						slots: a9.getA9SlotsDefinitions(Object.keys(bidderConfig.slots)),
+						timeout: DEFAULT_MAX_DELAY,
+					}),
+				).to.equal(true, 'fetchBids called with wrong arguments');
+				done();
+			});
 		});
 	});
 });

--- a/spec/ad-bidders/wrappers/apstag.spec.ts
+++ b/spec/ad-bidders/wrappers/apstag.spec.ts
@@ -1,0 +1,198 @@
+import { Apstag } from '@wikia/ad-bidders';
+import { context, targetingService, usp } from '@wikia/core';
+import { scriptLoader } from '@wikia/core/utils';
+import { OpenRtb2Object } from '@wikia/platforms/shared';
+import { expect } from 'chai';
+import { SinonSpy } from 'sinon';
+
+describe('Apstag', () => {
+	let apstagInitStub: SinonSpy;
+	let apstagFetchBidsStub: SinonSpy;
+	let apstagRpaStub: SinonSpy;
+	let scriptLoaderStub: SinonSpy;
+	const amazonId = 12345;
+
+	beforeEach(() => {
+		apstagInitStub = global.sandbox.spy();
+		apstagFetchBidsStub = global.sandbox.spy();
+		apstagRpaStub = global.sandbox.spy();
+		global.window.apstag = global.window.apstag || ({} as typeof global.window.apstag);
+		global.sandbox.stub(window, 'apstag').value({
+			init: apstagInitStub,
+			fetchBids: apstagFetchBidsStub,
+			rpa: apstagRpaStub,
+		});
+		scriptLoaderStub = global.sandbox.spy();
+		global.sandbox.stub(scriptLoader, 'loadScript').callsFake((src, defer, node) => {
+			scriptLoaderStub(src, defer, node);
+			return Promise.resolve(undefined);
+		});
+		context.set('bidders.a9.amazonId', amazonId);
+	});
+
+	afterEach(() => {
+		context.remove('bidders.a9.amazonId');
+	});
+
+	describe('make', () => {
+		it('returns single instance of Apstag', () => {
+			// given
+			const apstag1 = Apstag.make();
+
+			// when
+			const apstag2 = Apstag.make();
+
+			// then
+			expect(JSON.stringify(apstag1)).to.equal(JSON.stringify(apstag2));
+		});
+
+		it('should load apstag.js script', () => {
+			// given + when
+			Apstag.reset();
+
+			// then
+			expect(
+				scriptLoaderStub.calledWithExactly('//c.amazon-adsystem.com/aax2/apstag.js', true, 'first'),
+			).to.be.true;
+		});
+	});
+
+	describe('init', () => {
+		it('should call window.apstag.init with config', async () => {
+			// given
+			const apstag = Apstag.reset();
+
+			// when
+			await apstag.init();
+
+			// then
+			expect(apstagInitStub.calledOnce).to.be.true;
+			expect(
+				apstagInitStub.calledWithExactly({
+					pubID: amazonId,
+					videoAdServer: 'DFP',
+					deals: true,
+					signals: { ortb2: {} },
+				}),
+			).to.be.true;
+		});
+
+		it('should call window.apstag.init with config containing CCPA signal', async () => {
+			// given
+			const apstag = Apstag.reset();
+			const uspString = '1---';
+			global.sandbox.stub(usp, 'exists').value(true);
+			global.sandbox.stub(usp, 'getSignalData').callsFake(() => Promise.resolve({ uspString }));
+
+			// when
+			await apstag.init();
+
+			// then
+			expect(apstagInitStub.calledOnce).to.be.true;
+			expect(
+				apstagInitStub.calledWithExactly({
+					pubID: amazonId,
+					videoAdServer: 'DFP',
+					deals: true,
+					params: {
+						us_privacy: uspString,
+					},
+					signals: { ortb2: {} },
+				}),
+			).to.be.true;
+		});
+
+		it('should call window.apstag.init with config containing OpenRTB2 signals', async () => {
+			// given
+			const apstag = Apstag.reset();
+			const ortb2 = {
+				site: {
+					id: '1234',
+				},
+				user: {},
+			} as OpenRtb2Object;
+			global.sandbox.stub(targetingService, 'get').withArgs('openrtb2', 'openrtb2').returns(ortb2);
+
+			// when
+			await apstag.init();
+
+			// then
+			expect(apstagInitStub.calledOnce).to.be.true;
+			expect(
+				apstagInitStub.calledWithExactly({
+					pubID: amazonId,
+					videoAdServer: 'DFP',
+					deals: true,
+					signals: { ortb2 },
+				}),
+			).to.be.true;
+		});
+
+		it('should send HEM to Amazon when user is logged in', async () => {
+			// given
+			const apstag = Apstag.reset();
+			global.sandbox
+				.stub(context, 'get')
+				.withArgs('wiki.opts.userEmailHashes')
+				.returns(['hash1', 'hash2', 'hash3'])
+				.withArgs('bidders.a9.rpa')
+				.returns(true);
+
+			// when
+			await apstag.init();
+
+			// then
+			expect(
+				apstagRpaStub.calledWithExactly({ hashedRecords: [{ type: 'email', record: 'hash3' }] }),
+			).to.be.true;
+		});
+	});
+
+	describe('sendHEM', () => {
+		it('should send provided HEM once', async () => {
+			// given
+			const apstag = Apstag.reset();
+			global.sandbox.stub(context, 'get').withArgs('bidders.a9.rpa').returns(true);
+			global.sandbox
+				.stub(apstag.storage, 'getItem')
+				.onFirstCall()
+				.returns(undefined)
+				.onSecondCall()
+				.returns('1');
+
+			// when
+			await apstag.sendHEM('hash');
+			await apstag.sendHEM('hash');
+
+			// then
+			expect(apstagRpaStub.callCount).to.equal(1);
+			expect(
+				apstagRpaStub.calledWithExactly({ hashedRecords: [{ type: 'email', record: 'hash' }] }),
+			).to.be.true;
+		});
+
+		it('should not send HEM when feature flag is disabled', async () => {
+			// given
+			const apstag = Apstag.reset();
+			global.sandbox.stub(context, 'get').withArgs('bidders.a9.rpa').returns(false);
+
+			// when
+			await apstag.sendHEM('hash');
+
+			// then
+			expect(apstagRpaStub.notCalled).to.be.true;
+		});
+
+		it('should not send HEM when it was already sent to Amazon', async () => {
+			// given
+			const apstag = Apstag.reset();
+			global.sandbox.stub(apstag.storage, 'getItem').returns('1');
+
+			// when
+			await apstag.sendHEM('hash');
+
+			// then
+			expect(apstagRpaStub.notCalled).to.be.true;
+		});
+	});
+});

--- a/src/ad-bidders/a9/index.ts
+++ b/src/ad-bidders/a9/index.ts
@@ -68,7 +68,6 @@ export class A9Provider extends BidderProvider {
 		this.slots = this.bidderConfig.slots;
 		this.slotsNames = Object.keys(this.slots);
 		this.bidsRefreshing = context.get('bidders.a9.bidsRefreshing') || {};
-		this.apstag.init();
 	}
 
 	getTargetingKeys(): string[] {

--- a/src/ad-bidders/a9/index.ts
+++ b/src/ad-bidders/a9/index.ts
@@ -68,13 +68,14 @@ export class A9Provider extends BidderProvider {
 		this.slots = this.bidderConfig.slots;
 		this.slotsNames = Object.keys(this.slots);
 		this.bidsRefreshing = context.get('bidders.a9.bidsRefreshing') || {};
+		this.apstag.init();
 	}
 
 	getTargetingKeys(): string[] {
 		return this.targetingKeys;
 	}
 
-	private initIfNotLoaded(): void {
+	private async initIfNotLoaded(): Promise<void> {
 		if (!this.loaded) {
 			if (context.get('custom.hasFeaturedVideo')) {
 				communicationService.onSlotEvent(AdSlotEvent.VIDEO_AD_IMPRESSION, ({ slot }) =>
@@ -90,7 +91,7 @@ export class A9Provider extends BidderProvider {
 				);
 			}
 
-			this.apstag.init();
+			await this.apstag.init();
 
 			if (!trackingOptIn.isOptedIn() || trackingOptIn.isOptOutSale()) {
 				utils.logger(logGroup, 'A9 was initialized without consents');
@@ -326,14 +327,12 @@ export class A9Provider extends BidderProvider {
 		}
 	}
 
-	protected async callBids(): Promise<void> {
-		this.initIfNotLoaded();
-
+	protected callBids(): void {
 		this.bids = {};
 		this.priceMap = {};
 		const a9Slots = this.getA9SlotsDefinitions(this.slotsNames);
 
-		this.fetchBids(a9Slots);
+		this.initIfNotLoaded().then(() => this.fetchBids(a9Slots));
 	}
 
 	calculatePrices(): void {

--- a/src/ad-bidders/a9/index.ts
+++ b/src/ad-bidders/a9/index.ts
@@ -9,28 +9,16 @@ import {
 	context,
 	DEFAULT_MAX_DELAY,
 	Dictionary,
-	externalLogger,
 	SlotConfig,
 	slotService,
 	targetingService,
 	trackingOptIn,
-	Usp,
-	usp,
 	utils,
 } from '@ad-engine/core';
 import { getSlotNameByBidderAlias } from '../alias-helper';
 import { BidderProvider, BidsRefreshing } from '../bidder-provider';
 import { Apstag } from '../wrappers';
-import {
-	A9Bid,
-	A9Bids,
-	A9CCPA,
-	A9Config,
-	A9SlotConfig,
-	A9SlotDefinition,
-	ApstagConfig,
-	PriceMap,
-} from './types';
+import { A9Bid, A9Bids, A9Config, A9SlotConfig, A9SlotDefinition, PriceMap } from './types';
 
 const logGroup = 'A9Provider';
 
@@ -38,18 +26,6 @@ export class A9Provider extends BidderProvider {
 	static A9_CLASS = 'a9-ad';
 	static VIDEO_TTL = 10 * 60 * 1000; // 10 minutes for video bid to expire
 	private static isApstagConfigured = false;
-
-	private static getCcpaIfApplicable(signalData: SignalData): Partial<A9CCPA> {
-		if (signalData && signalData.uspString) {
-			return {
-				params: {
-					us_privacy: signalData.uspString,
-				},
-			};
-		}
-
-		return {};
-	}
 
 	private static mapResponseToTrackingBidDefinition(
 		slotName: string,
@@ -77,7 +53,6 @@ export class A9Provider extends BidderProvider {
 
 	apstag: Apstag = Apstag.make();
 	bids: A9Bids = {};
-	usp: Usp = usp;
 	priceMap: PriceMap = {};
 	targetingKeys: string[] = [];
 
@@ -99,17 +74,7 @@ export class A9Provider extends BidderProvider {
 		return this.targetingKeys;
 	}
 
-	init(signalData: SignalData = {}): void {
-		this.initIfNotLoaded(signalData);
-
-		this.bids = {};
-		this.priceMap = {};
-		const a9Slots = this.getA9SlotsDefinitions(this.slotsNames);
-
-		this.fetchBids(a9Slots);
-	}
-
-	private initIfNotLoaded(signalData: SignalData): void {
+	private initIfNotLoaded(): void {
 		if (!this.loaded) {
 			if (context.get('custom.hasFeaturedVideo')) {
 				communicationService.onSlotEvent(AdSlotEvent.VIDEO_AD_IMPRESSION, ({ slot }) =>
@@ -125,7 +90,7 @@ export class A9Provider extends BidderProvider {
 				);
 			}
 
-			this.apstag.init(this.getApstagConfig(signalData));
+			this.apstag.init();
 
 			if (!trackingOptIn.isOptedIn() || trackingOptIn.isOptOutSale()) {
 				utils.logger(logGroup, 'A9 was initialized without consents');
@@ -159,19 +124,6 @@ export class A9Provider extends BidderProvider {
 				targetingService.remove(key, adSlot.getSlotName());
 			});
 		}
-	}
-
-	private getApstagConfig(signalData: SignalData): ApstagConfig {
-		const ortb2 = targetingService.get('openrtb2', 'openrtb2');
-		externalLogger.log('openrtb2 signals', { signals: JSON.stringify(ortb2) });
-
-		return {
-			pubID: this.amazonId,
-			videoAdServer: 'DFP',
-			deals: true,
-			...A9Provider.getCcpaIfApplicable(signalData),
-			signals: { ortb2 },
-		};
 	}
 
 	/**
@@ -375,13 +327,13 @@ export class A9Provider extends BidderProvider {
 	}
 
 	protected async callBids(): Promise<void> {
-		let signalData = null;
+		this.initIfNotLoaded();
 
-		if (this.usp.exists) {
-			signalData = await this.usp.getSignalData();
-		}
+		this.bids = {};
+		this.priceMap = {};
+		const a9Slots = this.getA9SlotsDefinitions(this.slotsNames);
 
-		this.init(signalData);
+		this.fetchBids(a9Slots);
 	}
 
 	calculatePrices(): void {

--- a/src/ad-bidders/wrappers/apstag.ts
+++ b/src/ad-bidders/wrappers/apstag.ts
@@ -1,22 +1,46 @@
-import { utils } from '@ad-engine/core';
-import { A9Bid, A9BidConfig } from '../a9/types';
+import { communicationService, eventsRepository } from '@ad-engine/communication';
+import {
+	context,
+	externalLogger,
+	targetingService,
+	UniversalStorage,
+	Usp,
+	usp,
+	utils,
+} from '@ad-engine/core';
+import { A9Bid, A9BidConfig, A9CCPA, ApstagConfig } from '../a9/types';
+
+const logGroup = 'Apstag';
 
 export class Apstag {
 	private static instance: Apstag;
 
 	static make(): Apstag {
 		if (!Apstag.instance) {
-			Apstag.instance = new Apstag();
+			Apstag.reset();
 		}
+
+		return Apstag.instance;
+	}
+
+	/**
+	 * @deprecated
+	 * Used in unit tests.
+	 */
+	static reset(): Apstag {
+		Apstag.instance = new Apstag();
 
 		return Apstag.instance;
 	}
 
 	private script: Promise<Event>;
 	private renderImpEndCallbacks = [];
+	storage: UniversalStorage;
 	utils = utils;
+	usp: Usp = usp;
 
 	private constructor() {
+		this.storage = new UniversalStorage();
 		this.insertScript();
 		this.configure();
 		this.addRenderImpHook();
@@ -28,6 +52,32 @@ export class Apstag {
 			true,
 			'first',
 		);
+	}
+
+	public sendMediaWikiHEM(): void {
+		const userEmailHashes: [string, string, string] = context.get('wiki.opts.userEmailHashes');
+		if (!Array.isArray(userEmailHashes) || userEmailHashes?.length !== 3) {
+			return;
+		}
+		const record = userEmailHashes[2];
+		this.sendHEM(record);
+	}
+
+	public async sendHEM(record: string): Promise<void> {
+		if (this.storage.getItem('apstagHEMsent') === '1' || !context.get('bidders.a9.rpa')) {
+			return;
+		}
+
+		const tokenConfig = { hashedRecords: [{ type: 'email', record }] };
+		try {
+			await this.script;
+			utils.logger(logGroup, 'Sending HEM to apstag', tokenConfig);
+			window.apstag.rpa(tokenConfig);
+			this.storage.setItem('apstagHEMsent', '1');
+			communicationService.emit(eventsRepository.A9_APSTAG_HEM_SENT);
+		} catch (e) {
+			utils.logger(logGroup, 'Error sending HEM to apstag', e);
+		}
 	}
 
 	private configure(): void {
@@ -62,9 +112,17 @@ export class Apstag {
 		window.apstag._Q.push([command, args]);
 	}
 
-	async init(apsConfig): Promise<void> {
+	async init(): Promise<void> {
+		let signalData = null;
+
+		if (this.usp.exists) {
+			signalData = await this.usp.getSignalData();
+		}
+
+		const apsConfig = this.getApstagConfig(signalData);
 		await this.script;
 		window.apstag.init(apsConfig);
+		this.sendMediaWikiHEM();
 	}
 
 	async fetchBids(bidsConfig: A9BidConfig): Promise<A9Bid[]> {
@@ -99,5 +157,31 @@ export class Apstag {
 			throw new Error('onRenderImpEnd used with callback not being a function');
 		}
 		this.renderImpEndCallbacks.push(callback);
+	}
+
+	private getApstagConfig(signalData: SignalData): ApstagConfig {
+		const amazonId = context.get('bidders.a9.amazonId');
+		const ortb2 = targetingService.get('openrtb2', 'openrtb2');
+		externalLogger.log('openrtb2 signals', { signals: JSON.stringify(ortb2) });
+
+		return {
+			pubID: amazonId,
+			videoAdServer: 'DFP',
+			deals: true,
+			...Apstag.getCcpaIfApplicable(signalData),
+			signals: { ortb2 },
+		};
+	}
+
+	private static getCcpaIfApplicable(signalData: SignalData): Partial<A9CCPA> {
+		if (signalData && signalData.uspString) {
+			return {
+				params: {
+					us_privacy: signalData.uspString,
+				},
+			};
+		}
+
+		return {};
 	}
 }

--- a/src/ad-bidders/wrappers/apstag.ts
+++ b/src/ad-bidders/wrappers/apstag.ts
@@ -10,7 +10,7 @@ import {
 } from '@ad-engine/core';
 import { A9Bid, A9BidConfig, A9CCPA, ApstagConfig } from '../a9/types';
 
-const logGroup = 'Apstag';
+const logGroup = 'a9-apstag';
 
 export class Apstag {
 	private static instance: Apstag;

--- a/src/communication/event-types.ts
+++ b/src/communication/event-types.ts
@@ -324,6 +324,9 @@ export const eventsRepository: Dictionary<EventOptions> = {
 	A9_WITHOUT_CONSENTS: {
 		name: 'A9 without consents',
 	},
+	A9_APSTAG_HEM_SENT: {
+		name: 'A9 Apstag HEM sent',
+	},
 	BIDDERS_BIDDING_DONE: {
 		category: '[Prebid]',
 		name: 'Bidding done',

--- a/src/platforms/shared/modes/no-ads.mode.ts
+++ b/src/platforms/shared/modes/no-ads.mode.ts
@@ -1,6 +1,8 @@
 import {
+	Apstag,
 	Audigent,
 	communicationService,
+	context,
 	DiProcess,
 	eventsRepository,
 	Experian,
@@ -29,6 +31,9 @@ export class NoAdsMode implements DiProcess {
 		this.removeAdSlotsPlaceholders();
 		this.noAdsDetector.addReasons(window.ads.context.opts.noAdsReasons);
 		this.dispatchJWPlayerSetupAction();
+		if (context.get('state.isLogged')) {
+			Apstag.make().init();
+		}
 
 		this.pipeline
 			.add(this.liveRampPixel, this.audigent, this.eyeota, this.liveConnect, this.experian)

--- a/src/platforms/shared/setup/base-context.setup.ts
+++ b/src/platforms/shared/setup/base-context.setup.ts
@@ -197,6 +197,7 @@ export class BaseContextSetup implements DiProcess {
 		);
 		context.set('bidders.s2s.bidders', this.instantConfig.get('icPrebidS2sBidders', []));
 		context.set('bidders.s2s.enabled', this.instantConfig.get('icPrebidS2sBidders', []).length > 0);
+		context.set('bidders.a9.rpa', this.instantConfig.get('icA9HEM'));
 	}
 
 	private setupStickySlotContext(): void {

--- a/src/platforms/shared/tracking/load-times-tracker.ts
+++ b/src/platforms/shared/tracking/load-times-tracker.ts
@@ -18,6 +18,7 @@ const eventsToTrack = {
 	eyeota_started: eventsRepository.EYEOTA_STARTED,
 	eyeota_failed: eventsRepository.EYEOTA_FAILED,
 	a9_without_consents: eventsRepository.A9_WITHOUT_CONSENTS,
+	a9_apstag_hem_sent: eventsRepository.A9_APSTAG_HEM_SENT,
 	intentiq_ppid_not_set_on_time: eventsRepository.INTENTIQ_PPID_NOT_SET_ON_TIME,
 	intentiq_start: eventsRepository.INTENTIQ_START,
 	intentiq_done: eventsRepository.INTENTIQ_DONE,

--- a/src/platforms/shared/tracking/tracking.setup.ts
+++ b/src/platforms/shared/tracking/tracking.setup.ts
@@ -1,5 +1,6 @@
 import {
 	adClickTracker,
+	Apstag,
 	Bidders,
 	bidderTracker,
 	communicationService,
@@ -59,13 +60,19 @@ export class TrackingSetup {
 			communicationService.on(
 				eventsRepository.IDENTITY_PARTNER_DATA_OBTAINED,
 				(eventInfo) => {
+					const { partnerName, partnerIdentityId } = eventInfo.payload;
 					this.dwTracker.track(
 						{
-							partner_name: eventInfo.payload.partnerName,
-							partner_identity_id: eventInfo.payload.partnerIdentityId,
+							partner_name: partnerName,
+							partner_identity_id: partnerIdentityId,
 						},
 						trackingUrls.IDENTITY_INFO,
 					);
+
+					if (['liveConnect', 'MediaWiki-sha256'].includes(partnerName)) {
+						const apstag = Apstag.make();
+						apstag.init().then(() => apstag.sendHEM(partnerIdentityId));
+					}
 				},
 				false,
 			);


### PR DESCRIPTION
### JIRA
[ADEN-13681](https://fandom.atlassian.net/browse/ADEN-13681)
[TACO-176](https://fandom.atlassian.net/browse/TACO-176)

### Description

Implements integration with Apstag `window.apstag.rpa` method. This method collects user HEM (provided by MediaWiki or LiveConnect) and provides Amazon Token that can be later on used by Apstag and A9 bidder.
This PR fixes previous problems introduced in #2163 which were caused by race condition... Before it could be a problem as well as we were not waiting for `apstag.init`, but in majority of cases it was working as expected. After some moving of code pieces the race condition was more easy to obtain.

[Fixed code diff vs previous implementation](https://github.com/Wikia/ad-engine/compare/v146.2.0...ADEN-13681-fix#diff-8e4e1901f435f31bd531736bed3ed6c16b4449e151d3330f823b99814294f637)

[ADEN-13681]: https://fandom.atlassian.net/browse/ADEN-13681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TACO-176]: https://fandom.atlassian.net/browse/TACO-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ