### PR TITLE
COTECH-807 Use specific Anyclip embed codes per wiki genre

### DIFF
--- a/spec/ad-services/anyclip/anyclip.spec.ts
+++ b/spec/ad-services/anyclip/anyclip.spec.ts
@@ -4,7 +4,13 @@ import {
 	communicationService,
 	CommunicationService,
 } from '@wikia/communication/communication-service';
-import { context, InstantConfigService, utils } from '@wikia/core';
+import {
+	context,
+	InstantConfigService,
+	targetingService,
+	TargetingService,
+	utils,
+} from '@wikia/core';
 import { WaitFor } from '@wikia/core/utils';
 import { expect } from 'chai';
 import { SinonStubbedInstance } from 'sinon';
@@ -18,6 +24,7 @@ describe('Anyclip', () => {
 
 	let loadScriptStub, instantConfigStub;
 	let communicationServiceStub: SinonStubbedInstance<CommunicationService>;
+	let targetingServiceStub: SinonStubbedInstance<TargetingService>;
 
 	beforeEach(() => {
 		global.sandbox.stub(WaitFor.prototype, 'until').returns(Promise.resolve());
@@ -37,6 +44,7 @@ describe('Anyclip', () => {
 				callback(payload);
 			},
 		);
+		targetingServiceStub = global.sandbox.stub(targetingService);
 	});
 
 	afterEach(() => {
@@ -99,8 +107,8 @@ describe('Anyclip', () => {
 		});
 	});
 
-	it("sets up widgetname under the key named after the current Wiki's vertical", () => {
-		window.mw = { config: new Map([['wikiVertical', 'anime']]) } as MediaWiki;
+	it('sets up widgetname under the key named after the current vertical', () => {
+		targetingServiceStub.get.withArgs('s0v').returns('anime');
 		context.set('services.anyclip.widgetname', { anime: 'anime-widget' });
 
 		anyclip = new Anyclip(instantConfigStub);
@@ -110,8 +118,8 @@ describe('Anyclip', () => {
 		});
 	});
 
-	it("sets up widgetname under the 'default' key when the current Wiki's vertical isn't mapped to any specific widgetname", () => {
-		window.mw = { config: new Map([['wikiVertical', 'gaming']]) } as MediaWiki;
+	it("sets up widgetname under the 'default' key when the current vertical isn't mapped to any specific widgetname", () => {
+		targetingServiceStub.get.withArgs('s0v').returns('games');
 		context.set('services.anyclip.widgetname', { default: 'test-widget' });
 
 		anyclip = new Anyclip(instantConfigStub);
@@ -122,7 +130,7 @@ describe('Anyclip', () => {
 	});
 
 	it("sets up the default Anyclip widgetname if there's no default key provided", () => {
-		window.mw = { config: new Map([['wikiVertical', 'gaming']]) } as MediaWiki;
+		targetingServiceStub.get.withArgs('s0v').returns('games');
 		context.set('services.anyclip.widgetname', { anime: 'anime-widget' });
 
 		anyclip = new Anyclip(instantConfigStub);

--- a/spec/ad-services/anyclip/anyclip.spec.ts
+++ b/spec/ad-services/anyclip/anyclip.spec.ts
@@ -20,7 +20,6 @@ describe('Anyclip', () => {
 	let mockedIsApplicable;
 	const mockIsApplicable = () => true;
 	const mockIsNotApplicable = () => false;
-	const originalWindowMw: MediaWiki = window?.mw;
 
 	let loadScriptStub, instantConfigStub;
 	let communicationServiceStub: SinonStubbedInstance<CommunicationService>;
@@ -51,7 +50,6 @@ describe('Anyclip', () => {
 		loadScriptStub.resetHistory();
 		global.sandbox.restore();
 
-		window.mw = originalWindowMw;
 		context.remove('custom.hasFeaturedVideo');
 		context.remove('services.anyclip.loadWithoutAnchor');
 		context.remove('services.anyclip.isApplicable');

--- a/spec/ad-services/anyclip/anyclip.spec.ts
+++ b/spec/ad-services/anyclip/anyclip.spec.ts
@@ -14,6 +14,7 @@ describe('Anyclip', () => {
 	let mockedIsApplicable;
 	const mockIsApplicable = () => true;
 	const mockIsNotApplicable = () => false;
+	const originalWindowMw: MediaWiki = window?.mw;
 
 	let loadScriptStub, instantConfigStub;
 	let communicationServiceStub: SinonStubbedInstance<CommunicationService>;
@@ -42,6 +43,7 @@ describe('Anyclip', () => {
 		loadScriptStub.resetHistory();
 		global.sandbox.restore();
 
+		window.mw = originalWindowMw;
 		context.remove('custom.hasFeaturedVideo');
 		context.remove('services.anyclip.loadWithoutAnchor');
 		context.remove('services.anyclip.isApplicable');
@@ -94,6 +96,39 @@ describe('Anyclip', () => {
 		expect(anyclip.params).to.deep.equal({
 			pubname: 'test-pubname',
 			widgetname: 'test-widget',
+		});
+	});
+
+	it("sets up widgetname under the key named after the current Wiki's vertical", () => {
+		window.mw = { config: new Map([['wikiVertical', 'anime']]) } as MediaWiki;
+		context.set('services.anyclip.widgetname', { anime: 'anime-widget' });
+
+		anyclip = new Anyclip(instantConfigStub);
+
+		expect(anyclip.params).to.deep.include({
+			widgetname: 'anime-widget',
+		});
+	});
+
+	it("sets up widgetname under the 'default' key when the current Wiki's vertical isn't mapped to any specific widgetname", () => {
+		window.mw = { config: new Map([['wikiVertical', 'gaming']]) } as MediaWiki;
+		context.set('services.anyclip.widgetname', { default: 'test-widget' });
+
+		anyclip = new Anyclip(instantConfigStub);
+
+		expect(anyclip.params).to.deep.include({
+			widgetname: 'test-widget',
+		});
+	});
+
+	it("sets up the default Anyclip widgetname if there's no default key provided", () => {
+		window.mw = { config: new Map([['wikiVertical', 'gaming']]) } as MediaWiki;
+		context.set('services.anyclip.widgetname', { anime: 'anime-widget' });
+
+		anyclip = new Anyclip(instantConfigStub);
+
+		expect(anyclip.params).to.deep.include({
+			widgetname: '001w000001Y8ud2_19593',
 		});
 	});
 

--- a/src/ad-services/anyclip/index.ts
+++ b/src/ad-services/anyclip/index.ts
@@ -5,9 +5,9 @@ import {
 	context,
 	slotDataParamsUpdater,
 	slotService,
+	targetingService,
 	utils,
 } from '@ad-engine/core';
-import { getMediaWikiVariable } from '../../platforms/shared';
 import { AnyclipBidsRefresher } from './anyclip-bids-refresher';
 import { AnyclipTracker } from './anyclip-tracker';
 
@@ -37,7 +37,7 @@ export class Anyclip extends BaseServiceSetup {
 		}
 
 		if (typeof widgetNameParam === 'object') {
-			const wikiVertical = getMediaWikiVariable('wikiVertical');
+			const wikiVertical = targetingService.get('s0v');
 			return widgetNameParam[wikiVertical] || widgetNameParam['default'] || DEFAULT_WIDGET_NAME;
 		}
 

--- a/src/ad-services/anyclip/index.ts
+++ b/src/ad-services/anyclip/index.ts
@@ -32,12 +32,16 @@ export class Anyclip extends BaseServiceSetup {
 	private get widgetname(): string {
 		const widgetNameParam = context.get('services.anyclip.widgetname');
 
-		if (typeof widgetNameParam !== 'object') {
+		if (['string', 'undefined'].includes(typeof widgetNameParam)) {
 			return widgetNameParam || DEFAULT_WIDGET_NAME;
 		}
 
-		const wikiVertical = getMediaWikiVariable('wikiVertical');
-		return widgetNameParam[wikiVertical] || widgetNameParam['default'] || DEFAULT_WIDGET_NAME;
+		if (typeof widgetNameParam === 'object') {
+			const wikiVertical = getMediaWikiVariable('wikiVertical');
+			return widgetNameParam[wikiVertical] || widgetNameParam['default'] || DEFAULT_WIDGET_NAME;
+		}
+
+		return DEFAULT_WIDGET_NAME;
 	}
 
 	private get libraryUrl(): string {

--- a/src/ad-services/anyclip/index.ts
+++ b/src/ad-services/anyclip/index.ts
@@ -7,10 +7,12 @@ import {
 	slotService,
 	utils,
 } from '@ad-engine/core';
+import { getMediaWikiVariable } from '../../platforms/shared';
 import { AnyclipBidsRefresher } from './anyclip-bids-refresher';
 import { AnyclipTracker } from './anyclip-tracker';
 
 const logGroup = 'Anyclip';
+const DEFAULT_WIDGET_NAME = '001w000001Y8ud2_19593';
 const SUBSCRIBE_FUNC_NAME = 'lreSubscribe';
 const isSubscribeReady = () => typeof window[SUBSCRIBE_FUNC_NAME] !== 'undefined';
 const isPlayerAdSlotReady = (slotName = 'incontent_player') => {
@@ -28,7 +30,14 @@ export class Anyclip extends BaseServiceSetup {
 	}
 
 	private get widgetname(): string {
-		return context.get('services.anyclip.widgetname') || '001w000001Y8ud2_19593';
+		const widgetNameParam = context.get('services.anyclip.widgetname');
+
+		if (typeof widgetNameParam !== 'object') {
+			return widgetNameParam || DEFAULT_WIDGET_NAME;
+		}
+
+		const wikiVertical = getMediaWikiVariable('wikiVertical');
+		return widgetNameParam[wikiVertical] || widgetNameParam['default'] || DEFAULT_WIDGET_NAME;
 	}
 
 	private get libraryUrl(): string {

--- a/src/platforms/ucp-desktop/ad-context.ts
+++ b/src/platforms/ucp-desktop/ad-context.ts
@@ -65,6 +65,15 @@ export const basicContext = {
 			'.mw-parser-output > h2,.mw-parser-output > h3,.mw-parser-output > h4,.mw-parser-output > h5',
 	},
 	services: {
+		anyclip: {
+			pubname: 'fandomcom',
+			widgetname: {
+				anime: '001w000001Y8ud2AAB_M8447',
+				gaming: '001w000001Y8ud2AAB_M8446',
+			},
+			libraryUrl: 'https://player.anyclip.com/anyclip-widget/lre-widget/prod/v1/src/lre.js',
+			latePageInject: true,
+		},
 		doubleVerify: {
 			slots: [
 				'top_leaderboard',

--- a/src/platforms/ucp-desktop/ad-context.ts
+++ b/src/platforms/ucp-desktop/ad-context.ts
@@ -72,7 +72,6 @@ export const basicContext = {
 				games: '001w000001Y8ud2AAB_M8446',
 			},
 			libraryUrl: 'https://player.anyclip.com/anyclip-widget/lre-widget/prod/v1/src/lre.js',
-			latePageInject: true,
 		},
 		doubleVerify: {
 			slots: [

--- a/src/platforms/ucp-desktop/ad-context.ts
+++ b/src/platforms/ucp-desktop/ad-context.ts
@@ -69,7 +69,7 @@ export const basicContext = {
 			pubname: 'fandomcom',
 			widgetname: {
 				anime: '001w000001Y8ud2AAB_M8447',
-				gaming: '001w000001Y8ud2AAB_M8446',
+				games: '001w000001Y8ud2AAB_M8446',
 			},
 			libraryUrl: 'https://player.anyclip.com/anyclip-widget/lre-widget/prod/v1/src/lre.js',
 			latePageInject: true,

--- a/src/platforms/ucp-mobile/ad-context.ts
+++ b/src/platforms/ucp-mobile/ad-context.ts
@@ -61,7 +61,7 @@ export const basicContext = {
 			pubname: 'fandomcom',
 			widgetname: {
 				anime: '001w000001Y8ud2AAB_M8449',
-				gaming: '001w000001Y8ud2AAB_M8448',
+				games: '001w000001Y8ud2AAB_M8448',
 				default: '001w000001Y8ud2AAB_M6237',
 			},
 			libraryUrl: 'https://player.anyclip.com/anyclip-widget/lre-widget/prod/v1/src/lre.js',

--- a/src/platforms/ucp-mobile/ad-context.ts
+++ b/src/platforms/ucp-mobile/ad-context.ts
@@ -59,7 +59,11 @@ export const basicContext = {
 	services: {
 		anyclip: {
 			pubname: 'fandomcom',
-			widgetname: '001w000001Y8ud2AAB_M6237',
+			widgetname: {
+				anime: '001w000001Y8ud2AAB_M8449',
+				gaming: '001w000001Y8ud2AAB_M8448',
+				default: '001w000001Y8ud2AAB_M6237',
+			},
 			libraryUrl: 'https://player.anyclip.com/anyclip-widget/lre-widget/prod/v1/src/lre.js',
 			latePageInject: true,
 		},


### PR DESCRIPTION
This PR updates the Anyclip configuration for both desktop and mobile UCP, allowing us to use different embed codes based on the current vertical.

The `widgetname` should be the only unique parameter. Anyclip can use that to configure various things on their side (e.g., ad schedule) without us doing anything further. No plans to make this more complex in the future. It's possible we decide at some point to add more `widgetname` options that allow configuration of yet smaller cohorts of users, but "genre" is the only solid idea we have today.