### PR TITLE
Add npm script to run HTTPS dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"setup": "npm ci && npm run prepare",
 		"build:platforms": "webpack --config webpack.platforms.js --mode=production",
 		"dev:platforms": "webpack-dev-server --progress --config webpack.platforms.js --mode=development",
+		"dev-https:platforms": "npm run dev:platforms -- --server-type https",
 		"bundle-analyzer": "webpack --config webpack.platforms.js --mode=production --env platform=ucp-desktop && webpack-bundle-analyzer dist/platforms/stats.json",
 		"ci-check": "npm run test && npm run lint",
 		"lint": "npx eslint . --ext .ts --max-warnings 0",


### PR DESCRIPTION
This script simplifies serving platforms over HTTPS using a self-signed certificate. It's a commonly used method for locally testing changes with the `adengine_version=local_https` parameter.