### PR TITLE
TACO-182 Handle franchise key values on N&R sites

### DIFF
--- a/spec/platforms/news-and-ratings/shared/context/targeting/news-and-ratings-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/shared/context/targeting/news-and-ratings-targeting.setup.spec.ts
@@ -116,5 +116,21 @@ describe('News and Ratings Targeting Setup', () => {
 
 			expect(mappedAdTags).to.be.deep.eq(expectedMappedAdTags);
 		});
+
+		it("getMappedAdTags correctly maps franchise key to 'franchise_nr' and franchiseRoot to 'franchise'", () => {
+			const parsedAdTags = {
+				franchise: 'test-franchise',
+				franchiseRoot: 'test-franchise-root',
+			};
+
+			const expectedMappedAdTags = {
+				franchise_nr: 'test-franchise',
+				franchise: 'test-franchise-root',
+			};
+
+			const mappedAdTags = newsAndRatingsTargetingSetup.getMappedAdTags(parsedAdTags);
+
+			expect(mappedAdTags).to.be.deep.eq(expectedMappedAdTags);
+		});
 	});
 });

--- a/src/platforms/news-and-ratings/shared/setup/context/targeting/interfaces/targeting-params.ts
+++ b/src/platforms/news-and-ratings/shared/setup/context/targeting/interfaces/targeting-params.ts
@@ -11,6 +11,7 @@ export interface TargetingParams extends CookieBasedTargetingParams {
 	contentid_nr?: string;
 	collection?: string;
 	franchise?: string;
+	franchiseRoot?: string;
 	game?: string;
 	gnre?: string;
 	env?: string;

--- a/src/platforms/news-and-ratings/shared/setup/context/targeting/news-and-ratings-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/context/targeting/news-and-ratings-targeting.setup.ts
@@ -87,6 +87,17 @@ export class NewsAndRatingsTargetingSetup implements DiProcess {
 				mappedAdTags['tv'] = value;
 				continue;
 			}
+
+			if (key === 'franchise') {
+				mappedAdTags['franchise_nr'] = value;
+				continue;
+			}
+
+			if (key === 'franchiseRoot') {
+				mappedAdTags['franchise'] = value;
+				continue;
+			}
+
 			mappedAdTags[key] = value;
 		}
 


### PR DESCRIPTION
### Ticket
https://fandom.atlassian.net/browse/TACO-182

### Description
On N&R sites "old" `franchise` key should be renamed to `franchise_nr` and the "old" franchise values should go there.
The new franchise values that are available in ad-tags meta tag under `franchiseRoot` key, should go to "new" `franchise` key 