### PR TITLE
COTECH-840 Fix Anyclip enabler on N&R

### DIFF
--- a/src/platforms/news-and-ratings/comicvine/ad-context.ts
+++ b/src/platforms/news-and-ratings/comicvine/ad-context.ts
@@ -27,7 +27,6 @@ export const basicContext = {
 	},
 	services: {
 		anyclip: {
-			enabled: false,
 			pubname: '2033',
 			miniPlayerWidgetname: '001w000001Y8ud2AAB_M7540',
 			libraryUrl: '//player.anyclip.com/anyclip-widget/lre-widget/prod/v1/src/acins.js',

--- a/src/platforms/news-and-ratings/shared/setup/context/base/news-and-ratings-base-context.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/context/base/news-and-ratings-base-context.setup.ts
@@ -77,6 +77,7 @@ export class NewsAndRatingsBaseContextSetup implements DiProcess {
 			'options.video.comscoreJwpTracking',
 			this.instantConfig.get('icComscoreJwpTracking'),
 		);
+		context.set('services.anyclip.enabled', this.instantConfig.get('icAnyclipPlayer'));
 		context.set(
 			'services.anyclip.anyclipTagExists',
 			!!this.getDataSettingsFromMetaTag()?.anyclip ||


### PR DESCRIPTION
In https://github.com/Wikia/ad-engine/pull/2209 I've changed the way how Anyclip services judge it's enabled or not and added similar to N&R way of calculating if it's applicable: https://github.com/Wikia/ad-engine/pull/2209/files#diff-7343fa1748a33287b2a8e4ded255b34f2943ff38233061ae882b28f0468fdf4aR126. This way whenever we want to test Connatix we block Anyclip. But the `BaseContextSetup` when I override default value of `enable` flag for Anyclip isn't used in the News&Ratings setup and thus we missed that with this change we disabled Anyclip there because it started using the default values, for example: https://github.com/Wikia/ad-engine/blob/62d593526a7b2138b9f5d12f499cd1ab9c587d94/src/platforms/news-and-ratings/comicvine/ad-context.ts#L30

It is a quick regression fix, so I didn't move Connatix > Anyclip logic to N&R.