### PR TITLE
TACO-274 Simplify ID5 control group logic

### DIFF
--- a/@types/pbjs/index.d.ts
+++ b/@types/pbjs/index.d.ts
@@ -169,6 +169,7 @@ interface PrebidTargetingForAdUnits {
 
 interface PrebidUserIds {
 	id5id?: {
+		uid?: string;
 		ext?: {
 			abTestingControlGroup?: boolean;
 		};
@@ -211,4 +212,6 @@ interface Pbjs {
 	onEvent(name: string, callback: (...args: any[]) => void): void;
 
 	offEvent(name: string, callback: (...args: any[]) => void): void;
+
+	que: Array<() => void>;
 }

--- a/spec/ad-bidders/prebid/id5/id5.spec.ts
+++ b/spec/ad-bidders/prebid/id5/id5.spec.ts
@@ -1,5 +1,5 @@
 import { id5 } from '@wikia/ad-bidders/prebid/id5';
-import { context, targetingService } from '@wikia/core';
+import { context } from '@wikia/core';
 import { expect } from 'chai';
 import { PbjsStub, stubPbjs } from '../../../core/services/pbjs.stub';
 
@@ -72,46 +72,25 @@ describe('Id5', () => {
 		expect(id5.getConfig().params.abTesting.controlGroupPct).to.eql(0.9);
 	});
 
-	describe('setupAbTesting', () => {
-		it('should not set targeting parameter if control group is not found', () => {
-			const targetingServiceStub = global.sandbox.stub(targetingService, 'set');
-
-			id5.setupAbTesting(pbjsStub);
-
-			expect(targetingServiceStub.called).to.eql(false);
-		});
-
-		it('should set targeting parameter to "U" if control group is undefined', async () => {
-			const targetingServiceStub = global.sandbox.stub(targetingService, 'set');
+	describe('getControlGroup', () => {
+		it('returns B when user is in the control group', async () => {
 			pbjsStub.getUserIds.returns({
-				id5id: { id: '1234567890abcdef', ext: { abTestingControlGroup: undefined } },
+				id5id: { uid: '0' },
 			});
 
-			await id5.setupAbTesting(pbjsStub);
+			const controlGroup = await id5.getControlGroup(pbjsStub);
 
-			expect(targetingServiceStub.calledOnceWithExactly('id5_group', 'U')).to.be.true;
+			expect(controlGroup).to.eql('B');
 		});
 
-		it('should set targeting parameter to "A" if control group is "true"', async () => {
-			const targetingServiceStub = global.sandbox.stub(targetingService, 'set');
+		it('returns A when user is not in the control group', async () => {
 			pbjsStub.getUserIds.returns({
-				id5id: { id: '1234567890abcdef', ext: { abTestingControlGroup: true } },
+				id5id: { uid: 'uid123456abcdef' },
 			});
 
-			await id5.setupAbTesting(pbjsStub);
+			const controlGroup = await id5.getControlGroup(pbjsStub);
 
-			expect(targetingServiceStub.calledOnceWithExactly('id5_group', 'A')).to.be.true;
-		});
-
-		it('should set targeting parameter to "B" if control group is "false"', async () => {
-			const targetingServiceStub = global.sandbox.stub(targetingService, 'set');
-			pbjsStub.getUserIds.returns({
-				id5id: { id: '1234567890abcdef', ext: { abTestingControlGroup: false } },
-			});
-
-			await id5.setupAbTesting(pbjsStub);
-
-			expect(targetingServiceStub.calledOnceWithExactly('id5_group', 'B')).to.be.true;
+			expect(controlGroup).to.eql('A');
 		});
 	});
 });

--- a/spec/core/services/pbjs.stub.ts
+++ b/spec/core/services/pbjs.stub.ts
@@ -23,6 +23,7 @@ export function createPbjsStub(sandbox: SinonSandbox): PbjsStub {
 		onEvent: sandbox.stub(),
 		offEvent: sandbox.stub(),
 		getAdserverTargeting: sandbox.stub(),
+		que: sandbox.stub() as any,
 	};
 }
 

--- a/src/ad-bidders/prebid/id5/id5.ts
+++ b/src/ad-bidders/prebid/id5/id5.ts
@@ -1,5 +1,5 @@
 import { communicationService, eventsRepository } from '@ad-engine/communication';
-import { context, targetingService, UniversalStorage, utils } from '@ad-engine/core';
+import { context, targetingService, utils } from '@ad-engine/core';
 import { UserIdConfig } from '../index';
 
 interface Id5Config extends UserIdConfig {
@@ -16,12 +16,7 @@ const logGroup = 'Id5';
 
 class Id5 {
 	private partnerId = 1139;
-	private storage;
 	private id5GroupKey = 'id5_group';
-
-	constructor() {
-		this.storage = new UniversalStorage();
-	}
 
 	private isEnabled(): boolean {
 		return (
@@ -73,51 +68,44 @@ class Id5 {
 		return this.partnerId;
 	}
 
-	async setupAbTesting(pbjs: Pbjs): Promise<void> {
-		const controlGroup =
-			this.getControlGroupFromStorage() || (await this.getControlGroupFromPbjsObject(pbjs));
+	async trackControlGroup(pbjs: Pbjs): Promise<void> {
+		const controlGroup = await this.getControlGroup(pbjs);
 
 		utils.logger(logGroup, 'Control group', controlGroup);
 
 		this.setTargeting(this.id5GroupKey, controlGroup);
-
-		if (controlGroup && controlGroup !== 'U') {
-			this.saveInStorage(this.id5GroupKey, controlGroup);
-		}
 	}
 
-	private getControlGroupFromStorage(): id5GroupValue {
-		const storageValue = this.storage.getItem(this.id5GroupKey);
+	public async getControlGroup(pbjs: Pbjs): Promise<id5GroupValue> {
+		await new utils.WaitFor(() => pbjs.getUserIds()?.id5id?.uid !== undefined, 10, 20).until();
+		const uid = pbjs.getUserIds()?.id5id?.uid;
 
-		if (storageValue !== null) {
-			return storageValue;
-		}
-	}
-
-	private async getControlGroupFromPbjsObject(pbjs: Pbjs): Promise<id5GroupValue> {
-		await new utils.WaitFor(() => pbjs.getUserIds()?.id5id?.ext !== undefined, 10, 20).until();
-
-		const controlGroup = pbjs.getUserIds()?.id5id?.ext?.abTestingControlGroup;
-
-		if (controlGroup === undefined) {
+		if (uid === undefined) {
 			return 'U';
 		}
 
-		return controlGroup === true ? 'A' : 'B';
-	}
-
-	private saveInStorage(key: string, value: string) {
-		if (this.storage.getItem(key) !== null) {
-			return;
-		}
-
-		this.storage.setItem(this.id5GroupKey, value);
-		utils.logger(logGroup, key, 'saved in storage', value);
+		// if user is in the control group then uid is 0
+		return uid === '0' ? 'B' : 'A';
 	}
 
 	private setTargeting(key: string, value: string): void {
 		targetingService.set(key, value);
 		utils.logger(logGroup, 'set targeting', key, value);
+	}
+
+	public enableAnalytics(pbjs: Pbjs): void {
+		if (context.get('bidders.prebid.id5Analytics.enabled')) {
+			utils.logger(logGroup, 'enabling ID5 Analytics');
+
+			pbjs.que.push(() => {
+				(window as any).pbjs.enableAnalytics({
+					provider: 'id5Analytics',
+					options: {
+						partnerId: this.partnerId,
+					},
+				});
+			});
+		}
 	}
 }
 

--- a/src/ad-bidders/prebid/index.ts
+++ b/src/ad-bidders/prebid/index.ts
@@ -232,12 +232,12 @@ export class PrebidProvider extends BidderProvider {
 
 		this.prebidConfig.userSync.userIds.push(id5Config);
 
+		const pbjs: Pbjs = await pbjsFactory.init();
 		if (id5Config.params.abTesting.enabled) {
-			const pbjs: Pbjs = await pbjsFactory.init();
-			await id5.setupAbTesting(pbjs);
+			id5.trackControlGroup(pbjs);
 		}
 
-		this.enableId5Analytics();
+		id5.enableAnalytics(pbjs);
 		communicationService.emit(eventsRepository.ID5_DONE);
 	}
 
@@ -267,21 +267,6 @@ export class PrebidProvider extends BidderProvider {
 				},
 			},
 		});
-	}
-
-	private enableId5Analytics(): void {
-		if (context.get('bidders.prebid.id5Analytics.enabled')) {
-			utils.logger(logGroup, 'enabling ID5 Analytics');
-
-			(window as any).pbjs.que.push(() => {
-				(window as any).pbjs.enableAnalytics({
-					provider: 'id5Analytics',
-					options: {
-						partnerId: id5.getPartnerId(),
-					},
-				});
-			});
-		}
 	}
 
 	private configureTCF(): object {


### PR DESCRIPTION
### Description
Turns out that when ID5 `uid` is equal to 0, it means that the user is in the A/B testing Control Group.
With this information there is no more need for saving control group in local storage, so this logic can be removed