### PR TITLE
COTECH-695 | Fix hasVideoOnPage

### DIFF
--- a/src/platforms/shared/context/targeting/targeting-strategies/providers/common-tags.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/providers/common-tags.ts
@@ -82,12 +82,10 @@ export class CommonTags implements TargetingProvider<Partial<SlotTargeting>> {
 		if (featuredVideoData) {
 			// Comparing with false in order to make sure that API already responds with "isDedicatedForArticle" flag
 			const isDedicatedForArticle = featuredVideoData.isDedicatedForArticle !== false;
-			const bridgeVideoPlayed =
-				!isDedicatedForArticle && window.canPlayVideo && window.canPlayVideo();
 
 			return {
 				isDedicatedForArticle,
-				hasVideoOnPage: isDedicatedForArticle || bridgeVideoPlayed,
+				hasVideoOnPage: window?.canPlayVideo(),
 			};
 		}
 


### PR DESCRIPTION
https://fandom.atlassian.net/browse/COTECH-695

`canPlayVideo` method is a source of truth to determine if the FV is rendered on the page. 

See definition here: https://github.com/Wikia/unified-platform/blob/b7b9cbf018f8e4291e9afb9a0a9cc66ed262c837/extensions/fandom/ArticleVideo/src/templates/ArticleVideoController_session.php#L59-L67