### PR TITLE
ADEN-12076 | disable ads for logged in users of gamepedia wikis

### DIFF
--- a/src/platforms/ucp-desktop/setup/context/base/ucp-desktop-base-context.setup.ts
+++ b/src/platforms/ucp-desktop/setup/context/base/ucp-desktop-base-context.setup.ts
@@ -7,6 +7,13 @@ export class UcpDesktopBaseContextSetup extends BaseContextSetup {
 	execute(): void {
 		super.execute();
 
+		const isGamepedia = window.ads.context.opts.isGamepedia;
+		const isLoggedIn = window.mw.config.get('wgUserId');
+
+		if (isGamepedia && isLoggedIn) {
+			this.noAdsDetector.addReason('gamepedia_loggedin_desktop_no_ads');
+		}
+
 		context.set(
 			'options.floatingMedrecDestroyable',
 			this.instantConfig.get('icFloatingMedrecDestroyable'),

--- a/src/platforms/ucp-mobile/setup/context/base/ucp-mobile-base-context.setup.ts
+++ b/src/platforms/ucp-mobile/setup/context/base/ucp-mobile-base-context.setup.ts
@@ -7,6 +7,13 @@ export class UcpMobileBaseContextSetup extends BaseContextSetup {
 	execute(): void {
 		super.execute();
 
+		const isGamepedia = window.ads.context.opts.isGamepedia;
+		const isLoggedIn = window.mw.config.get('wgUserId');
+
+		if (isGamepedia && isLoggedIn) {
+			this.noAdsDetector.addReason('gamepedia_loggedin_mobile_no_ads');
+		}
+
 		context.set(
 			'custom.serverPrefix',
 			utils.geoService.isProperCountry(['AU', 'NZ']) ? 'vm1b' : 'wka1b',


### PR DESCRIPTION
## Ticket: https://fandom.atlassian.net/browse/ADEN-12076
### Description
- using `?adengine_version=local` query param both on `fandomdesktop` and `fandommobile` skins when user is logged in on `gamepedia` wikis should result with displaying no ads, 
- nothing should be changed for not logged in users.