### PR TITLE
ADEN-13438 Quick-fix for bottom ads being too close to each other

### DIFF
--- a/src/platforms/news-and-ratings/gamespot/styles.scss
+++ b/src/platforms/news-and-ratings/gamespot/styles.scss
@@ -31,4 +31,8 @@ body:not(.skybox-loaded) {
 	}
 }
 
+.mapped-incontent-ad-plus-billboard-bottom.page-spacing-rem {
+	margin-top: 4rem;
+}
+
 @include out-of-page-styles();


### PR DESCRIPTION
It changes the bottom ads on desktop so instead of displaying like this:
![Screenshot 2023-12-05 at 17 11 32](https://github.com/Wikia/ad-engine/assets/1662451/56a49162-9547-49ae-ac02-ca3fe2b51244)
They display with a spacing like this:
![Screenshot 2023-12-05 at 17 17 10](https://github.com/Wikia/ad-engine/assets/1662451/b6ffa94b-2234-42f0-bc42-d1daa7d0f622)

That's a quick-fix before holidays ;-) A follow-up would be implementing it in Gamespot repository.