### PR TITLE
TACO-206 Ozone should not create large set of key-vals

### DIFF
--- a/src/ad-bidders/prebid/index.ts
+++ b/src/ad-bidders/prebid/index.ts
@@ -130,6 +130,10 @@ export class PrebidProvider extends BidderProvider {
 				video: videoGranularity,
 				'video-outstream': videoGranularity,
 			},
+			ozone: {
+				enhancedAdserverTargeting: false,
+				oz_whitelist_adserver_keys: [],
+			},
 			rubicon: {
 				singleRequest: true,
 			},


### PR DESCRIPTION
## Links
https://fandom.atlassian.net/browse/TACO-206

## Description
Ozone adds a lot of keyvals to GAM requests. See screenshot below:
![ozone_keyvals](https://github.com/Wikia/ad-engine/assets/124168110/58b62889-ad3c-4831-bb4b-90633a3baac7)

We do not need most (or all) of them, so we are going to filter them out using functionality that is hidden inside of Ozone's Prebid Module: https://github.com/Wikia/Prebid.js/blob/master/modules/ozoneBidAdapter.js#L481
I have added `oz_whitelist_adserver_keys` if we would like to provide allowlist of keyvals in the future instead of filtering out all of them.
