### PR TITLE
ADEN-13747 - Refresh bids for ICB2+

### DIFF
--- a/src/ad-services/bt-rec/index.ts
+++ b/src/ad-services/bt-rec/index.ts
@@ -7,7 +7,7 @@ type BTDetail = { detail: { ab: boolean } };
 /**
  * BT service handler
  */
-class BTRec {
+export class BTRec {
 	/**
 	 * Runs BT rec service and injects code
 	 */

--- a/src/communication/event-types.ts
+++ b/src/communication/event-types.ts
@@ -211,6 +211,9 @@ export const eventsRepository = {
 	EYEOTA_FAILED: {
 		name: 'Eyeota loading failed',
 	},
+	ICB1_SLOT_DESTROYED: {
+		name: 'incontent_boxad_1 Ad Slot destroyed',
+	},
 	IDENTITY_ENGINE_READY: {
 		category: '[IdentityEngine]',
 		name: 'Identity ready',

--- a/src/communication/event-types.ts
+++ b/src/communication/event-types.ts
@@ -177,8 +177,8 @@ export const eventsRepository = {
 		name: 'Ad clicked',
 		payload: props<Dictionary>(),
 	},
-	ICB1_SLOT_DESTROYED: {
-		name: 'incontent_boxad_1 Ad Slot destroyed',
+	ICB_SLOT_DESTROYED: {
+		name: 'Ad Slot incontent_boxad_* destroyed',
 	},
 	// Integrated partners events //
 	IDENTITY_PARTNER_DATA_OBTAINED: {

--- a/src/platforms/ucp-desktop/ad-context.ts
+++ b/src/platforms/ucp-desktop/ad-context.ts
@@ -14,25 +14,13 @@ export const basicContext = {
 			videoEnabled: false,
 			amazonId: '3115',
 			bidsRefreshing: {
-				slots: [
-					'featured',
-					'gallery_leaderboard',
-					'incontent_boxad_1',
-					'incontent_boxad_2',
-					'incontent_leaderboard',
-				],
+				slots: ['featured', 'gallery_leaderboard', 'incontent_leaderboard'],
 			},
 		},
 		prebid: {
 			enabled: false,
 			bidsRefreshing: {
-				slots: [
-					'gallery_leaderboard',
-					'incontent_boxad_1',
-					'incontent_boxad_2',
-					'incontent_leaderboard',
-					'incontent_player',
-				],
+				slots: ['gallery_leaderboard', 'incontent_leaderboard', 'incontent_player'],
 			},
 		},
 	},
@@ -85,7 +73,6 @@ export const basicContext = {
 				'top_leaderboard',
 				'top_boxad',
 				'incontent_boxad_1',
-				'incontent_boxad_2',
 				'incontent_leaderboard',
 				'gallery_leaderboard',
 				'bottom_leaderboard',
@@ -106,7 +93,6 @@ export const basicContext = {
 				'top_leaderboard',
 				'top_boxad',
 				'incontent_boxad_1',
-				'incontent_boxad_2',
 				'incontent_leaderboard',
 				'gallery_leaderboard',
 				'bottom_leaderboard',

--- a/src/platforms/ucp-desktop/ad-context.ts
+++ b/src/platforms/ucp-desktop/ad-context.ts
@@ -14,7 +14,13 @@ export const basicContext = {
 			videoEnabled: false,
 			amazonId: '3115',
 			bidsRefreshing: {
-				slots: ['featured', 'gallery_leaderboard', 'incontent_boxad_1', 'incontent_leaderboard'],
+				slots: [
+					'featured',
+					'gallery_leaderboard',
+					'incontent_boxad_1',
+					'incontent_boxad_2',
+					'incontent_leaderboard',
+				],
 			},
 		},
 		prebid: {
@@ -23,6 +29,7 @@ export const basicContext = {
 				slots: [
 					'gallery_leaderboard',
 					'incontent_boxad_1',
+					'incontent_boxad_2',
 					'incontent_leaderboard',
 					'incontent_player',
 				],
@@ -78,6 +85,7 @@ export const basicContext = {
 				'top_leaderboard',
 				'top_boxad',
 				'incontent_boxad_1',
+				'incontent_boxad_2',
 				'incontent_leaderboard',
 				'gallery_leaderboard',
 				'bottom_leaderboard',
@@ -98,6 +106,7 @@ export const basicContext = {
 				'top_leaderboard',
 				'top_boxad',
 				'incontent_boxad_1',
+				'incontent_boxad_2',
 				'incontent_leaderboard',
 				'gallery_leaderboard',
 				'bottom_leaderboard',

--- a/src/platforms/ucp-desktop/bidders/prebid/appnexus.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/appnexus.ts
@@ -24,6 +24,14 @@ export function getAppnexusContext(): object {
 				],
 				position: 'hivi',
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[160, 600],
+					[300, 600],
+					[300, 250],
+				],
+				position: 'hivi',
+			},
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/appnexus.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/appnexus.ts
@@ -24,14 +24,14 @@ export function getAppnexusContext(): object {
 				],
 				position: 'hivi',
 			},
-			incontent_boxad_2: {
-				sizes: [
-					[160, 600],
-					[300, 600],
-					[300, 250],
-				],
-				position: 'hivi',
-			},
+			// incontent_boxad_2: {
+			// 	sizes: [
+			// 		[160, 600],
+			// 		[300, 600],
+			// 		[300, 250],
+			// 	],
+			// 	position: 'hivi',
+			// },
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/appnexus.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/appnexus.ts
@@ -24,14 +24,6 @@ export function getAppnexusContext(): object {
 				],
 				position: 'hivi',
 			},
-			// incontent_boxad_2: {
-			// 	sizes: [
-			// 		[160, 600],
-			// 		[300, 600],
-			// 		[300, 250],
-			// 	],
-			// 	position: 'hivi',
-			// },
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/index-exchange.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/index-exchange.ts
@@ -24,6 +24,14 @@ export function getIndexExchangeContext(): object {
 				],
 				siteId: '185049',
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[160, 600],
+					[300, 600],
+					[300, 250],
+				],
+				siteId: '185049',
+			},
 			incontent_leaderboard: {
 				sizes: [[728, 90]],
 				siteId: '1019179',

--- a/src/platforms/ucp-desktop/bidders/prebid/magniteS2s.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/magniteS2s.ts
@@ -25,6 +25,13 @@ export function getMagniteS2sContext(): object {
 					[300, 250],
 				],
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[160, 600],
+					[300, 600],
+					[300, 250],
+				],
+			},
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/medianet.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/medianet.ts
@@ -31,6 +31,14 @@ export function getMedianetContext(): object {
 				cid: '8CU5JOKX4',
 				crid: '210414245',
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[300, 250],
+					[300, 600],
+				],
+				cid: '8CU5JOKX4',
+				crid: '210414245',
+			},
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/nobid.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/nobid.ts
@@ -24,6 +24,14 @@ export function getNobidContext(): object {
 				],
 				siteId: 21872987104,
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[300, 250],
+					[300, 600],
+					[160, 600],
+				],
+				siteId: 21872987104,
+			},
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/ozone.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/ozone.ts
@@ -33,11 +33,11 @@ export function getOzoneContext(): object {
 				pos: 'OZ_incontent_boxad',
 				placementId: '3500013048',
 			},
-			incontent_boxad_2: {
-				sizes: [[300, 250]],
-				pos: 'OZ_incontent_boxad',
-				placementId: '3500013048',
-			},
+			// incontent_boxad_2: {
+			// 	sizes: [[300, 250]],
+			// 	pos: 'OZ_incontent_boxad',
+			// 	placementId: '3500013048',
+			// },
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/ozone.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/ozone.ts
@@ -33,11 +33,6 @@ export function getOzoneContext(): object {
 				pos: 'OZ_incontent_boxad',
 				placementId: '3500013048',
 			},
-			// incontent_boxad_2: {
-			// 	sizes: [[300, 250]],
-			// 	pos: 'OZ_incontent_boxad',
-			// 	placementId: '3500013048',
-			// },
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/ozone.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/ozone.ts
@@ -33,6 +33,11 @@ export function getOzoneContext(): object {
 				pos: 'OZ_incontent_boxad',
 				placementId: '3500013048',
 			},
+			incontent_boxad_2: {
+				sizes: [[300, 250]],
+				pos: 'OZ_incontent_boxad',
+				placementId: '3500013048',
+			},
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/pubmatic.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/pubmatic.ts
@@ -37,6 +37,18 @@ export function getPubmaticContext(): object {
 					'/5441/INCONTENT_BOXAD_1_300x600@300x600',
 				],
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[160, 600],
+					[300, 600],
+					[300, 250],
+				],
+				ids: [
+					'/5441/INCONTENT_BOXAD_1_160x600@160x600',
+					'/5441/INCONTENT_BOXAD_1_300x250@300x250',
+					'/5441/INCONTENT_BOXAD_1_300x600@300x600',
+				],
+			},
 			incontent_leaderboard: {
 				sizes: [[728, 90]],
 				ids: ['5315748@728x90'],

--- a/src/platforms/ucp-desktop/bidders/prebid/roundel.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/roundel.ts
@@ -24,6 +24,14 @@ export function getRoundelContext(): object {
 				],
 				siteId: '820933',
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[160, 600],
+					[300, 600],
+					[300, 250],
+				],
+				siteId: '820933',
+			},
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/rubicon-display.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/rubicon-display.ts
@@ -39,18 +39,6 @@ export function getRubiconDisplayContext(): object {
 				siteId: '148804',
 				zoneId: '704676',
 			},
-			// incontent_boxad_2: {
-			// 	sizes: [
-			// 		[160, 600],
-			// 		[300, 600],
-			// 		[300, 250],
-			// 	],
-			// 	targeting: {
-			// 		loc: ['hivi'],
-			// 	},
-			// 	siteId: '148804',
-			// 	zoneId: '704676',
-			// },
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/rubicon-display.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/rubicon-display.ts
@@ -39,18 +39,18 @@ export function getRubiconDisplayContext(): object {
 				siteId: '148804',
 				zoneId: '704676',
 			},
-			incontent_boxad_2: {
-				sizes: [
-					[160, 600],
-					[300, 600],
-					[300, 250],
-				],
-				targeting: {
-					loc: ['hivi'],
-				},
-				siteId: '148804',
-				zoneId: '704676',
-			},
+			// incontent_boxad_2: {
+			// 	sizes: [
+			// 		[160, 600],
+			// 		[300, 600],
+			// 		[300, 250],
+			// 	],
+			// 	targeting: {
+			// 		loc: ['hivi'],
+			// 	},
+			// 	siteId: '148804',
+			// 	zoneId: '704676',
+			// },
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/rubicon-display.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/rubicon-display.ts
@@ -39,6 +39,18 @@ export function getRubiconDisplayContext(): object {
 				siteId: '148804',
 				zoneId: '704676',
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[160, 600],
+					[300, 600],
+					[300, 250],
+				],
+				targeting: {
+					loc: ['hivi'],
+				},
+				siteId: '148804',
+				zoneId: '704676',
+			},
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/bidders/prebid/triplelift.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/triplelift.ts
@@ -28,6 +28,18 @@ export function getTripleliftContext(): object {
 					'Fandom_DT_FMR_300x600_hdx_prebid',
 				],
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[160, 600],
+					[300, 600],
+					[300, 250],
+				],
+				inventoryCodes: [
+					'Fandom_DT_FMR_160x600_hdx_prebid',
+					'Fandom_DT_FMR_300x250_hdx_prebid',
+					'Fandom_DT_FMR_300x600_hdx_prebid',
+				],
+			},
 			incontent_leaderboard: {
 				sizes: [[728, 90]],
 				inventoryCodes: ['fandom_incontent_leaderboard'],

--- a/src/platforms/ucp-desktop/bidders/prebid/verizon.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/verizon.ts
@@ -15,6 +15,10 @@ export function getVerizonContext(): object {
 				sizes: [[300, 250]],
 				pos: 'incontent_boxad_1',
 			},
+			incontent_boxad_2: {
+				sizes: [[300, 250]],
+				pos: 'incontent_boxad_1',
+			},
 			bottom_leaderboard: {
 				sizes: [[728, 90]],
 				pos: 'bottom_leaderboard',

--- a/src/platforms/ucp-desktop/bidders/prebid/wikia.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/wikia.ts
@@ -11,6 +11,9 @@ export function getWikiaContext(): object {
 			incontent_boxad_1: {
 				sizes: [[300, 250]],
 			},
+			incontent_boxad_2: {
+				sizes: [[300, 250]],
+			},
 			incontent_leaderboard: {
 				sizes: [[728, 90]],
 			},

--- a/src/platforms/ucp-desktop/setup/context/a9/ucp-desktop-a9-config.setup.ts
+++ b/src/platforms/ucp-desktop/setup/context/a9/ucp-desktop-a9-config.setup.ts
@@ -33,6 +33,12 @@ export class UcpDesktopA9ConfigSetup implements DiProcess {
 					[300, 600],
 				],
 			},
+			incontent_boxad_2: {
+				sizes: [
+					[300, 250],
+					[300, 600],
+				],
+			},
 			bottom_leaderboard: {
 				sizes: [
 					[728, 90],

--- a/src/platforms/ucp-desktop/setup/context/slots/ucp-desktop-slots-context.setup.ts
+++ b/src/platforms/ucp-desktop/setup/context/slots/ucp-desktop-slots-context.setup.ts
@@ -75,6 +75,22 @@ export class UcpDesktopSlotsContextSetup implements DiProcess {
 					loc: 'hivi',
 				},
 			},
+			incontent_boxad_2: {
+				adProduct: 'incontent_boxad_2',
+				group: 'HiVi',
+				recirculationElementSelector: '#recirculation-rail',
+				sizes: [],
+				defaultSizes: [
+					[120, 600],
+					[160, 600],
+					[300, 250],
+					[300, 600],
+				],
+				targeting: {
+					loc: 'hivi',
+				},
+				bidGroup: 'incontent_boxad_2',
+			},
 			bottom_leaderboard: {
 				adProduct: 'bottom_leaderboard',
 				group: 'PF',

--- a/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-dynamic-slots.setup.ts
+++ b/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-dynamic-slots.setup.ts
@@ -67,9 +67,13 @@ export class UcpDesktopDynamicSlotsSetup implements DiProcess {
 			});
 		});
 
-		communicationService.on(eventsRepository.ICB1_SLOT_DESTROYED, () => {
-			insertSlots([this.slotsDefinitionRepository.getIncontentBoxad2Config()]);
-		});
+		communicationService.on(
+			eventsRepository.ICB_SLOT_DESTROYED,
+			() => {
+				insertSlots([this.slotsDefinitionRepository.getIncontentBoxad2Config()]);
+			},
+			false,
+		);
 
 		communicationService.on(
 			eventsRepository.QUIZ_AD_INJECTED,

--- a/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-dynamic-slots.setup.ts
+++ b/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-dynamic-slots.setup.ts
@@ -22,6 +22,8 @@ import { Injectable } from '@wikia/dependency-injection';
 import { UcpDesktopPerformanceAdsDefinitionRepository } from './ucp-desktop-performance-ads-definition-repository';
 import { UcpDesktopSlotsDefinitionRepository } from './ucp-desktop-slots-definition-repository';
 
+// let tmp = 0;
+
 @Injectable()
 export class UcpDesktopDynamicSlotsSetup implements DiProcess {
 	constructor(
@@ -70,6 +72,15 @@ export class UcpDesktopDynamicSlotsSetup implements DiProcess {
 		communicationService.on(
 			eventsRepository.ICB_SLOT_DESTROYED,
 			() => {
+				// if (tmp == 0) {
+				// 	targetingService.set('cid', 'adeng-collapse', 'incontent_boxad_2');
+				// 	console.log('incontent_boxad_2 - cid');
+				// 	tmp = 1;
+				// } else if (tmp == 1) {
+				// 	targetingService.remove('cid', 'incontent_boxad_2');
+				// 	console.log('incontent_boxad_2 - cid removed');
+				// 	tmp = 9999;
+				// }
 				insertSlots([this.slotsDefinitionRepository.getIncontentBoxad2Config()]);
 			},
 			false,
@@ -114,10 +125,6 @@ export class UcpDesktopDynamicSlotsSetup implements DiProcess {
 				'incontent_boxad_1',
 				universalAdPackage.UAP_ADDITIONAL_SIZES.companionSizes['5x5'].size,
 			);
-			slotsContext.addSlotSize(
-				'incontent_boxad_2',
-				universalAdPackage.UAP_ADDITIONAL_SIZES.companionSizes['5x5'].size,
-			);
 		} else {
 			context.set(`slots.${slotName}.sizes`, [
 				{
@@ -129,10 +136,6 @@ export class UcpDesktopDynamicSlotsSetup implements DiProcess {
 			context.set('slots.incontent_boxad_2.defaultSizes', [[300, 250]]);
 			slotsContext.addSlotSize(
 				'incontent_boxad_1',
-				universalAdPackage.UAP_ADDITIONAL_SIZES.companionSizes['4x4'].size,
-			);
-			slotsContext.addSlotSize(
-				'incontent_boxad_2',
 				universalAdPackage.UAP_ADDITIONAL_SIZES.companionSizes['4x4'].size,
 			);
 		}

--- a/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-dynamic-slots.setup.ts
+++ b/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-dynamic-slots.setup.ts
@@ -66,6 +66,11 @@ export class UcpDesktopDynamicSlotsSetup implements DiProcess {
 				this.performanceAdsDefinitionRepository.setup();
 			});
 		});
+
+		communicationService.on(eventsRepository.ICB1_SLOT_DESTROYED, () => {
+			insertSlots([this.slotsDefinitionRepository.getIncontentBoxad2Config()]);
+		});
+
 		communicationService.on(
 			eventsRepository.QUIZ_AD_INJECTED,
 			({ slotId }) => {
@@ -105,6 +110,10 @@ export class UcpDesktopDynamicSlotsSetup implements DiProcess {
 				'incontent_boxad_1',
 				universalAdPackage.UAP_ADDITIONAL_SIZES.companionSizes['5x5'].size,
 			);
+			slotsContext.addSlotSize(
+				'incontent_boxad_2',
+				universalAdPackage.UAP_ADDITIONAL_SIZES.companionSizes['5x5'].size,
+			);
 		} else {
 			context.set(`slots.${slotName}.sizes`, [
 				{
@@ -113,8 +122,13 @@ export class UcpDesktopDynamicSlotsSetup implements DiProcess {
 				},
 			]);
 			context.set('slots.incontent_boxad_1.defaultSizes', [[300, 250]]);
+			context.set('slots.incontent_boxad_2.defaultSizes', [[300, 250]]);
 			slotsContext.addSlotSize(
 				'incontent_boxad_1',
+				universalAdPackage.UAP_ADDITIONAL_SIZES.companionSizes['4x4'].size,
+			);
+			slotsContext.addSlotSize(
+				'incontent_boxad_2',
 				universalAdPackage.UAP_ADDITIONAL_SIZES.companionSizes['4x4'].size,
 			);
 		}

--- a/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-slots-definition-repository.ts
+++ b/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-slots-definition-repository.ts
@@ -218,7 +218,7 @@ export class UcpDesktopSlotsDefinitionRepository implements SlotsDefinitionRepos
 				slotName,
 				anchorSelector: '#WikiaAdInContentPlaceHolder',
 				insertMethod: 'append',
-				classList: [AdSlot.HIDDEN_AD_CLASS, 'ad-slot'],
+				classList: ['ad-slot'],
 			},
 		};
 	}

--- a/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-slots-definition-repository.ts
+++ b/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-slots-definition-repository.ts
@@ -193,17 +193,6 @@ export class UcpDesktopSlotsDefinitionRepository implements SlotsDefinitionRepos
 				anchorSelector: '#WikiaAdInContentPlaceHolder',
 				insertMethod: 'append',
 				classList: [AdSlot.HIDDEN_AD_CLASS, 'ad-slot'],
-				repeat: {
-					index: 1,
-					limit: 20,
-					slotNamePattern: `${slotNamePrefix}{slotConfig.repeat.index}`,
-					updateProperties: {
-						adProduct: '{slotConfig.slotName}',
-						'targeting.rv': '{slotConfig.repeat.index}',
-						'targeting.pos': ['incontent_boxad'],
-					},
-					disablePushOnScroll: true,
-				},
 			},
 			activator: () => {
 				const rotator = new FmrRotator(slotName, slotNamePrefix, btRec, {
@@ -213,6 +202,23 @@ export class UcpDesktopSlotsDefinitionRepository implements SlotsDefinitionRepos
 				communicationService.on(eventsRepository.AD_ENGINE_STACK_START, () => {
 					rotator.rotateSlot();
 				});
+			},
+		};
+	}
+
+	getIncontentBoxad2Config(): SlotSetupDefinition {
+		if (!this.isRightRailApplicable()) {
+			return;
+		}
+
+		const slotName = 'incontent_boxad_2';
+
+		return {
+			slotCreatorConfig: {
+				slotName,
+				anchorSelector: '#WikiaAdInContentPlaceHolder',
+				insertMethod: 'append',
+				classList: [AdSlot.HIDDEN_AD_CLASS, 'ad-slot'],
 			},
 		};
 	}

--- a/src/platforms/ucp-desktop/templates/handlers/bfaa/bfaa-ucp-desktop-config-handler.ts
+++ b/src/platforms/ucp-desktop/templates/handlers/bfaa/bfaa-ucp-desktop-config-handler.ts
@@ -15,6 +15,7 @@ export class BfaaUcpDesktopConfigHandler implements TemplateStateHandler {
 	private enabledSlots: string[] = [
 		'top_boxad',
 		'incontent_boxad_1',
+		'incontent_boxad_2',
 		'bottom_leaderboard',
 		'gallery_leaderboard',
 		'fandom_dt_galleries',
@@ -54,6 +55,7 @@ export class BfaaUcpDesktopConfigHandler implements TemplateStateHandler {
 			this.enabledSlots = [
 				'top_boxad',
 				'incontent_boxad_1',
+				'incontent_boxad_2',
 				'bottom_leaderboard',
 				'floor_adhesion',
 			];

--- a/src/platforms/ucp-desktop/templates/handlers/bfaa/bfaa-ucp-desktop-config-handler.ts
+++ b/src/platforms/ucp-desktop/templates/handlers/bfaa/bfaa-ucp-desktop-config-handler.ts
@@ -15,7 +15,6 @@ export class BfaaUcpDesktopConfigHandler implements TemplateStateHandler {
 	private enabledSlots: string[] = [
 		'top_boxad',
 		'incontent_boxad_1',
-		'incontent_boxad_2',
 		'bottom_leaderboard',
 		'gallery_leaderboard',
 		'fandom_dt_galleries',
@@ -55,7 +54,6 @@ export class BfaaUcpDesktopConfigHandler implements TemplateStateHandler {
 			this.enabledSlots = [
 				'top_boxad',
 				'incontent_boxad_1',
-				'incontent_boxad_2',
 				'bottom_leaderboard',
 				'floor_adhesion',
 			];

--- a/src/platforms/ucp-desktop/utils/fmr-rotator.ts
+++ b/src/platforms/ucp-desktop/utils/fmr-rotator.ts
@@ -182,16 +182,13 @@ export class FmrRotator {
 	}
 
 	private hideSlot(): void {
-		if (context.get('options.floatingMedrecDestroyable')) {
-			if (this.currentAdSlot.getSlotName() === 'incontent_boxad_1') {
-				communicationService.emit(eventsRepository.ICB1_SLOT_DESTROYED);
-			}
+		if (this.currentAdSlot.getSlotName() === 'incontent_boxad_1') {
+			communicationService.emit(eventsRepository.ICB1_SLOT_DESTROYED);
+		}
 
+		if (context.get('options.floatingMedrecDestroyable')) {
 			slotService.remove(this.currentAdSlot);
 		} else {
-			if (this.currentAdSlot.getSlotName() === 'incontent_boxad_1') {
-				communicationService.emit(eventsRepository.ICB1_SLOT_DESTROYED);
-			}
 			this.currentAdSlot.hide();
 		}
 
@@ -216,7 +213,7 @@ export class FmrRotator {
 		if (this.isRefreshLimitAvailable()) {
 			setTimeout(() => {
 				communicationService.emit(eventsRepository.BIDDERS_CALL_PER_GROUP, {
-					group: 'incontent_boxad_2',
+					group: this.nextSlotName,
 					callback: () => {
 						this.tryPushNextSlot();
 					},

--- a/src/platforms/ucp-desktop/utils/fmr-rotator.ts
+++ b/src/platforms/ucp-desktop/utils/fmr-rotator.ts
@@ -95,8 +95,8 @@ export class FmrRotator {
 					communicationService.onSlotEvent(
 						AdSlotStatus.STATUS_COLLAPSE,
 						() => {
-							this.slotStatusChanged(AdSlotStatus.STATUS_COLLAPSE);
-							this.scheduleNextSlotPush();
+							// this.slotStatusChanged(AdSlotStatus.STATUS_COLLAPSE);
+							this.removeSlot();
 						},
 						slot.getSlotName(),
 						true,

--- a/src/platforms/ucp-desktop/utils/fmr-rotator.ts
+++ b/src/platforms/ucp-desktop/utils/fmr-rotator.ts
@@ -9,6 +9,7 @@ import {
 	slotService,
 	universalAdPackage,
 	utils,
+	type BTRec,
 } from '@wikia/ad-engine';
 
 interface FmrRotatorConfig {
@@ -32,7 +33,7 @@ export class FmrRotator {
 	constructor(
 		private slotName: string,
 		private fmrPrefix: string,
-		private btRec,
+		private btRec: BTRec,
 		private config: FmrRotatorConfig,
 	) {}
 
@@ -182,8 +183,15 @@ export class FmrRotator {
 
 	private hideSlot(): void {
 		if (context.get('options.floatingMedrecDestroyable')) {
+			if (this.currentAdSlot.getSlotName() === 'incontent_boxad_1') {
+				communicationService.emit(eventsRepository.ICB1_SLOT_DESTROYED);
+			}
+
 			slotService.remove(this.currentAdSlot);
 		} else {
+			if (this.currentAdSlot.getSlotName() === 'incontent_boxad_1') {
+				communicationService.emit(eventsRepository.ICB1_SLOT_DESTROYED);
+			}
 			this.currentAdSlot.hide();
 		}
 
@@ -191,23 +199,28 @@ export class FmrRotator {
 		this.scheduleNextSlotPush();
 	}
 
-	private slotStatusChanged(slotStatus): void {
+	private slotStatusChanged(slotStatus: AdSlotStatus): void {
 		this.currentAdSlot = slotService.get(this.nextSlotName);
-		this.nextSlotName = this.fmrPrefix + this.refreshInfo.repeatIndex;
+		this.nextSlotName = 'incontent_boxad_2';
 
 		if (slotStatus === AdSlotStatus.STATUS_SUCCESS) {
 			this.swapRecirculation(false);
 		}
 	}
 
-	private swapRecirculation(visible): void {
+	private swapRecirculation(visible: boolean): void {
 		this.recirculationElement.style.display = visible ? 'block' : 'none';
 	}
 
 	private scheduleNextSlotPush(): void {
 		if (this.isRefreshLimitAvailable()) {
 			setTimeout(() => {
-				this.tryPushNextSlot();
+				communicationService.emit(eventsRepository.BIDDERS_CALL_PER_GROUP, {
+					group: 'incontent_boxad_2',
+					callback: () => {
+						this.tryPushNextSlot();
+					},
+				});
 			}, this.refreshInfo.refreshDelay);
 		}
 	}

--- a/src/platforms/ucp-desktop/utils/fmr-rotator.ts
+++ b/src/platforms/ucp-desktop/utils/fmr-rotator.ts
@@ -95,7 +95,8 @@ export class FmrRotator {
 					communicationService.onSlotEvent(
 						AdSlotStatus.STATUS_COLLAPSE,
 						() => {
-							// this.slotStatusChanged(AdSlotStatus.STATUS_COLLAPSE);
+							this.slotStatusChanged(AdSlotStatus.STATUS_COLLAPSE);
+
 							this.removeSlot();
 						},
 						slot.getSlotName(),
@@ -192,12 +193,12 @@ export class FmrRotator {
 
 		this.currentAdSlot.destroy();
 		this.currentAdSlot.getElement().remove();
+		this.swapRecirculation(true);
 		setTimeout(() => {
 			communicationService.emit(eventsRepository.ICB_SLOT_DESTROYED);
 
-			this.swapRecirculation(true);
 			this.scheduleNextSlotPush();
-		}, 1000);
+		}, 2000);
 	}
 
 	private slotStatusChanged(slotStatus: AdSlotStatus): void {

--- a/src/platforms/ucp-desktop/utils/fmr-rotator.ts
+++ b/src/platforms/ucp-desktop/utils/fmr-rotator.ts
@@ -178,6 +178,10 @@ export class FmrRotator {
 	}
 
 	private pushNextSlot(): void {
+		if (!this.isRefreshLimitAvailable()) {
+			return;
+		}
+
 		utils.logger(
 			'incontent_boxad_count',
 			`repeatIndex/repeatLimit: ${this.refreshInfo.repeatIndex} / ${this.refreshInfo.repeatLimit}`,
@@ -187,12 +191,11 @@ export class FmrRotator {
 	}
 
 	private removeSlot(): void {
-		if (!this.currentAdSlot) {
-			return;
+		if (this.currentAdSlot) {
+			slotService.remove(this.currentAdSlot);
+			this.currentAdSlot.getElement().remove();
 		}
 
-		this.currentAdSlot.destroy();
-		this.currentAdSlot.getElement().remove();
 		this.swapRecirculation(true);
 		setTimeout(() => {
 			communicationService.emit(eventsRepository.ICB_SLOT_DESTROYED);


### PR DESCRIPTION
## Links
Ticket: https://fandom.atlassian.net/browse/ADEN-13747
## Description

> [!WARNING]  
> TODO: reenable `ozone` bidders
> TODO: configure bidders with new slot data `for now most of the slots use ICB1 data (ids etc...)`

> [!NOTE]
slotName = `incontent_boxad_2`
repeatLimit = 20

### **simplified** flow
```mermaid
flowchart TD
    ICB1_slot_inserted-->ICB1_slot_added
    ICB1_slot_added-->ICB1_slot_bid
    ICB1_slot_bid-->ICB1_rendered
    ICB1_rendered-->ICB1_viewed
    ICB1_viewed-->ICB1_slot_destroyed
    ICB1_slot_destroyed-->|ICB1_SLOT_DESTROYED event| A
    A[ICB2_slots_inserted] --> B{ICB_slots_amount < 20?}
    B -->|Yes| C[ICB2_slot_added]
    C -->D[ICB2_slot_bid]
    D -->E[ICB2_viewed]
    E -->F[ICB2_slot_destroyed]
    F -->B
    B ---->|No| G[show Popular pages]
```
## Acceptance Criteria
> [!IMPORTANT]
> - `ICB1_SLOT_DESTROYED` event gets called when `incontent_box_1` slot gets `destroyed`
> - ICB2+ slots gets new A9 and Prebid bids before they are rendered


## Screenshots
<img width="1097" alt="image" src="https://github.com/Wikia/unified-platform/assets/149780256/56d674bb-d181-4709-ba0a-c3b3f62d62cc">
