### PR TITLE
TACO-364 Get InstantConfigLoader params from window.ads.context

### DIFF
--- a/@types/ads/index.d.ts
+++ b/@types/ads/index.d.ts
@@ -3,15 +3,33 @@ interface MediaWikiAds {
 	adContext: any;
 	adTargeting: any;
 	consentQueue: any;
-	context: MediaWikiAdsContext;
+	context: AdsContext;
 	debug: (groups: string | null) => void;
 	pushToConsentQueue: (callback: any) => void;
 	runtime: Runtime;
 }
 
-interface MediaWikiAdsContext {
-	opts: MediaWikiAdsOpts;
-	targeting: MediaWikiAdsTargeting;
+interface AdsContext {
+	// context set by loader, is available on all platforms
+	/**
+	 * appName as defined in AeLoader
+	 */
+	app: string;
+	/**
+	 * undefined means prod env
+	 */
+	env?: 'dev' | undefined;
+	/**
+	 * undefined means platform === app
+	 */
+	platform?: string;
+	/**
+	 * undefined means skin === app
+	 */
+	skin?: string;
+	// context set only on MediaWiki
+	opts?: MediaWikiAdsOpts;
+	targeting?: MediaWikiAdsTargeting;
 }
 
 interface MediaWikiAdsOpts {

--- a/spec/core/services/instant-config/instant-config.service.spec.ts
+++ b/spec/core/services/instant-config/instant-config.service.spec.ts
@@ -29,7 +29,9 @@ describe('Instant Config Service', () => {
 			getConfigStub.returns(Promise.resolve({}));
 			getValuesStub.returns({ testKey: 'testValue' });
 
-			const instantConfigService = await new InstantConfigService().init();
+			const instantConfigService = await new InstantConfigService({
+				appName: 'testapp',
+			}).init();
 
 			expect(instantConfigService.get('testKey')).to.equal('testValue');
 		});
@@ -37,7 +39,9 @@ describe('Instant Config Service', () => {
 		it('should pass InstantConfig to InstantConfigOverrider', async () => {
 			getConfigStub.returns(Promise.resolve({ config: true }));
 
-			await new InstantConfigService().init();
+			await new InstantConfigService({
+				appName: 'testapp',
+			}).init();
 
 			expect(overrideStub.firstCall.args[1]).to.deep.equal({ config: true });
 		});
@@ -47,7 +51,9 @@ describe('Instant Config Service', () => {
 			getValuesStub.returns({});
 			overrideStub.callsFake((_, input) => input);
 
-			await new InstantConfigService().init();
+			await new InstantConfigService({
+				appName: 'testapp',
+			}).init();
 
 			expect(initInterpreterStub.firstCall.args).to.deep.equal([
 				{ config: true },
@@ -61,7 +67,9 @@ describe('Instant Config Service', () => {
 			getValuesStub.returns({});
 			overrideStub.callsFake((_, input) => input);
 
-			await new InstantConfigService().init({ globals: true });
+			await new InstantConfigService({
+				appName: 'testapp',
+			}).init({ globals: true });
 
 			expect(initInterpreterStub.firstCall.args).to.deep.equal([
 				{ config: true },
@@ -74,7 +82,9 @@ describe('Instant Config Service', () => {
 			getConfigStub.returns(Promise.resolve({}));
 			getValuesStub.returns({});
 
-			await new InstantConfigService().init();
+			await new InstantConfigService({
+				appName: 'testapp',
+			}).init();
 			const numberOfCalls = getValuesStub.getCalls().length;
 
 			communicationService.emit(eventsRepository.AD_ENGINE_INSTANT_CONFIG_CACHE_RESET);
@@ -97,7 +107,9 @@ describe('Instant Config Service', () => {
 			getConfigStub.returns(Promise.resolve({}));
 			overrideStub.callsFake((input) => input);
 			getValuesStub.returns(repository);
-			instance = await new InstantConfigService().init();
+			instance = await new InstantConfigService({
+				appName: 'testapp',
+			}).init();
 		});
 
 		describe('get', () => {

--- a/spec/platforms/shared/tracking/tracking.setup.spec.ts
+++ b/spec/platforms/shared/tracking/tracking.setup.spec.ts
@@ -11,7 +11,9 @@ describe('TrackingSetup', () => {
 	const dwTracker = new DataWarehouseTracker();
 	const labradorTracker = new LabradorTracker(dwTracker);
 	const adSizeTracker = new AdSizeTracker(dwTracker);
-	const instantConfig = new InstantConfigService();
+	const instantConfig = new InstantConfigService({
+		appName: 'testapp',
+	});
 	const globalTimeout = new GlobalTimeout();
 	const bidders = new Bidders(instantConfig, globalTimeout);
 	let trackSpy: SinonSpy;

--- a/spec/platforms/shared/utils/instant-config.setup.spec.ts
+++ b/spec/platforms/shared/utils/instant-config.setup.spec.ts
@@ -6,7 +6,9 @@ import { SinonSpy, SinonStub } from 'sinon';
 
 describe('InstantConfigSetup', () => {
 	let container;
-	const instantConfigService = new InstantConfigService();
+	const instantConfigService = new InstantConfigService({
+		appName: 'testapp',
+	});
 	let containerBindStub: SinonStub;
 	let containerValueSpy: SinonSpy;
 
@@ -17,6 +19,12 @@ describe('InstantConfigSetup', () => {
 		containerBindStub = global.sandbox.stub(container, 'bind').returns({
 			value: containerValueSpy,
 		} as unknown as Binding<any>);
+		window.ads = {
+			...window.ads,
+			context: {
+				app: 'testapp',
+			},
+		};
 	});
 
 	it('should bind InstantConfigService to container', async () => {

--- a/src/core/services/instant-config/instant-config.service.ts
+++ b/src/core/services/instant-config/instant-config.service.ts
@@ -5,11 +5,12 @@ import {
 	DomainMatcher,
 	InstantConfigInterpreter,
 	InstantConfigLoader,
+	InstantConfigLoaderParams,
 	InstantConfigOverrider,
 	InstantConfigValue,
 	RegionMatcher,
 } from '@wikia/instant-config-loader';
-import { context, InstantConfigCacheStorage, utils } from '../../index';
+import { InstantConfigCacheStorage, utils } from '../../index';
 import { Dictionary } from '../../models';
 
 const logGroup = 'instant-config-service';
@@ -22,13 +23,10 @@ export class InstantConfigService implements InstantConfigServiceInterface {
 	private interpreter: InstantConfigInterpreter;
 	private repository: Dictionary<InstantConfigValue>;
 
+	constructor(private readonly params: InstantConfigLoaderParams) {}
+
 	async init(globals: Dictionary = {}): Promise<InstantConfigService> {
-		const instantConfigLoader = new InstantConfigLoader({
-			appName: context.get('services.instantConfig.appName'),
-			instantConfigEndpoint: context.get('services.instantConfig.endpoint'),
-			instantConfigVariant: context.get('wiki.services_instantConfig_variant'),
-			instantConfigFallbackEndpoint: context.get('services.instantConfig.fallback'),
-		});
+		const instantConfigLoader = new InstantConfigLoader(this.params);
 		const instantConfigInterpreter = new InstantConfigInterpreter(
 			new BrowserMatcher(utils.client.getBrowser()),
 			new DeviceMatcher(utils.client.getDeviceType() as unknown as string),

--- a/src/platforms/bingebot/ad-context.ts
+++ b/src/platforms/bingebot/ad-context.ts
@@ -9,12 +9,4 @@ export const basicContext = {
 	slots: {},
 	src: ['bingebot'],
 	wiki: {},
-	services: {
-		instantConfig: {
-			endpoint: 'https://services.fandom.com',
-			appName: 'bingebot',
-			fallback:
-				'https://script.wikia.nocookie.net/fandom-ae-assets/icbm/prod/icbm_state_bingebot.json',
-		},
-	},
 };

--- a/src/platforms/f2/ad-context.ts
+++ b/src/platforms/f2/ad-context.ts
@@ -42,11 +42,6 @@ export const basicContext = {
 		iasPublisherOptimization: {
 			slots: ['top_leaderboard', 'top_boxad', 'incontent_boxad', 'bottom_leaderboard', 'featured'],
 		},
-		instantConfig: {
-			endpoint: 'https://services.fandom.com',
-			appName: 'f2',
-			fallback: 'https://script.wikia.nocookie.net/fandom-ae-assets/icbm/prod/icbm_state_f2.json',
-		},
 		nielsen: {
 			customSection: 'news_and_stories',
 		},

--- a/src/platforms/news-and-ratings/comicvine/ad-context.ts
+++ b/src/platforms/news-and-ratings/comicvine/ad-context.ts
@@ -41,9 +41,6 @@ export const basicContext = {
 		iasPublisherOptimization: {
 			slots: ['mpu_top'],
 		},
-		instantConfig: {
-			appName: 'comicvine',
-		},
 	},
 	slots: {},
 	src: ['comicvine'],

--- a/src/platforms/news-and-ratings/gamefaqs/ad-context.ts
+++ b/src/platforms/news-and-ratings/gamefaqs/ad-context.ts
@@ -46,9 +46,6 @@ export const basicContext = {
 		iasPublisherOptimization: {
 			slots: ['mpu_top'],
 		},
-		instantConfig: {
-			appName: 'gamefaqs',
-		},
 	},
 	slots: {},
 	src: ['gamefaqs'],

--- a/src/platforms/news-and-ratings/gamespot/ad-context.ts
+++ b/src/platforms/news-and-ratings/gamespot/ad-context.ts
@@ -41,9 +41,6 @@ export const basicContext = {
 		iasPublisherOptimization: {
 			slots: ['mpu_top'],
 		},
-		instantConfig: {
-			appName: 'gamespot',
-		},
 	},
 	slots: {},
 	src: ['gamespot'],

--- a/src/platforms/news-and-ratings/giantbomb/ad-context.ts
+++ b/src/platforms/news-and-ratings/giantbomb/ad-context.ts
@@ -35,9 +35,6 @@ export const basicContext = {
 		iasPublisherOptimization: {
 			slots: ['mpu_top'],
 		},
-		instantConfig: {
-			appName: 'giantbomb',
-		},
 	},
 	slots: {},
 	src: ['giantbomb'],

--- a/src/platforms/news-and-ratings/metacritic-neutron/ad-context.ts
+++ b/src/platforms/news-and-ratings/metacritic-neutron/ad-context.ts
@@ -37,9 +37,6 @@ export const basicContext = {
 		iasPublisherOptimization: {
 			slots: ['mpu-plus-top'],
 		},
-		instantConfig: {
-			appName: 'metacritic-neutron',
-		},
 	},
 	slots: {},
 	src: ['metacritic'],

--- a/src/platforms/news-and-ratings/metacritic/ad-context.ts
+++ b/src/platforms/news-and-ratings/metacritic/ad-context.ts
@@ -35,9 +35,6 @@ export const basicContext = {
 		iasPublisherOptimization: {
 			slots: ['mpu_plus_top'],
 		},
-		instantConfig: {
-			appName: 'metacritic',
-		},
 	},
 	slots: {},
 	src: ['metacritic'],

--- a/src/platforms/news-and-ratings/tvguide-mtc/setup/wiki-context.setup.ts
+++ b/src/platforms/news-and-ratings/tvguide-mtc/setup/wiki-context.setup.ts
@@ -1,9 +1,7 @@
-import { context, DiProcess, targetingService } from '@wikia/ad-engine';
+import { DiProcess, targetingService } from '@wikia/ad-engine';
 
 export class TvGuideMTCContextSetup implements DiProcess {
 	execute(): void {
-		context.set('services.instantConfig.endpoint', 'https://services.fandom.com');
-		context.set('services.instantConfig.appName', 'tvguide-mtc');
 		targetingService.set('skin', 'tvguide-mtc');
 	}
 }

--- a/src/platforms/news-and-ratings/tvguide/ad-context.ts
+++ b/src/platforms/news-and-ratings/tvguide/ad-context.ts
@@ -77,9 +77,6 @@ export const basicContext = {
 		iasPublisherOptimization: {
 			slots: ['mpu-plus-top'],
 		},
-		instantConfig: {
-			appName: 'tvguide',
-		},
 	},
 	slots: {},
 	src: ['tvguide'],

--- a/src/platforms/shared/context/targeting/targeting-strategies/providers/common-tags.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/providers/common-tags.ts
@@ -15,7 +15,7 @@ export class CommonTags implements TargetingProvider<Partial<SlotTargeting>> {
 
 	public getCommonParams(): Partial<SlotTargeting> {
 		const domain = getDomain();
-		const wiki: MediaWikiAdsContext = context.get('wiki');
+		const wiki: AdsContext = context.get('wiki');
 		const isMobile = context.get('state.isMobile');
 
 		const commonParams: Partial<SlotTargeting> = {

--- a/src/platforms/shared/utils/instant-config.setup.ts
+++ b/src/platforms/shared/utils/instant-config.setup.ts
@@ -1,5 +1,6 @@
 import {
 	communicationService,
+	context,
 	DiProcess,
 	globalAction,
 	InstantConfigCacheStorage,
@@ -18,7 +19,19 @@ export class InstantConfigSetup implements DiProcess {
 	constructor(private container: Container) {}
 
 	async execute(): Promise<void> {
-		const instantConfig = await new InstantConfigService().init();
+		const { app, env, platform } = window.ads.context;
+		const appName = platform ?? app;
+		const instantConfigEndpoint =
+			env === 'dev' ? 'https://services.fandom-dev.pl' : 'https://services.fandom.com';
+		const instantConfigFallbackEndpoint = `https://script.wikia.nocookie.net/fandom-ae-assets/icbm/${
+			env ?? 'prod'
+		}/icbm_state_${appName}.json`;
+		const instantConfig = await new InstantConfigService({
+			appName,
+			instantConfigEndpoint,
+			instantConfigFallbackEndpoint,
+			instantConfigVariant: context.get('wiki.services_instantConfig_variant'),
+		}).init();
 
 		this.container.bind(InstantConfigService).value(instantConfig);
 		this.container.bind(InstantConfigCacheStorage).value(InstantConfigCacheStorage.make());

--- a/src/platforms/sports/ad-context.ts
+++ b/src/platforms/sports/ad-context.ts
@@ -51,12 +51,6 @@ const futheadContext = {
 		iasPublisherOptimization: {
 			slots: ['cdm-zone-01', 'cdm-zone-02', 'cdm-zone-03', 'cdm-zone-04', 'cdm-zone-06'],
 		},
-		instantConfig: {
-			endpoint: 'https://services.fandom.com',
-			appName: 'futhead',
-			fallback:
-				'https://script.wikia.nocookie.net/fandom-ae-assets/icbm/prod/icbm_state_futhead.json',
-		},
 	},
 };
 
@@ -71,12 +65,6 @@ const mutheadContext = {
 		},
 		iasPublisherOptimization: {
 			slots: ['cdm-zone-01', 'cdm-zone-02', 'cdm-zone-03', 'cdm-zone-04', 'cdm-zone-06'],
-		},
-		instantConfig: {
-			endpoint: 'https://services.fandom.com',
-			appName: 'muthead',
-			fallback:
-				'https://script.wikia.nocookie.net/fandom-ae-assets/icbm/prod/icbm_state_muthead.json',
 		},
 	},
 };

--- a/src/platforms/ucp-desktop/ad-context.ts
+++ b/src/platforms/ucp-desktop/ad-context.ts
@@ -108,12 +108,6 @@ export const basicContext = {
 		externalLogger: {
 			endpoint: '/wikia.php?controller=AdEngine&method=postLog',
 		},
-		instantConfig: {
-			endpoint: 'https://services.fandom.com',
-			appName: 'fandomdesktop',
-			fallback:
-				'https://script.wikia.nocookie.net/fandom-ae-assets/icbm/prod/icbm_state_fandomdesktop.json',
-		},
 		openWeb: {
 			placementSelector: '#WikiaAdInContentPlaceHolder',
 		},

--- a/src/platforms/ucp-mobile/ad-context.ts
+++ b/src/platforms/ucp-mobile/ad-context.ts
@@ -89,12 +89,6 @@ export const basicContext = {
 		externalLogger: {
 			endpoint: '/wikia.php?controller=AdEngine&method=postLog',
 		},
-		instantConfig: {
-			endpoint: 'https://services.fandom.com',
-			appName: 'fandommobile',
-			fallback:
-				'https://script.wikia.nocookie.net/fandom-ae-assets/icbm/prod/icbm_state_fandommobile.json',
-		},
 		iasPublisherOptimization: {
 			slots: [
 				'top_leaderboard',

--- a/src/platforms/ucp-no-ads/setup/wiki-context.setup.ts
+++ b/src/platforms/ucp-no-ads/setup/wiki-context.setup.ts
@@ -1,4 +1,4 @@
-import { context, DiProcess, targetingService } from '@wikia/ad-engine';
+import { DiProcess, targetingService } from '@wikia/ad-engine';
 
 export class UcpNoAdsWikiContextSetup implements DiProcess {
 	execute(): void {
@@ -6,8 +6,6 @@ export class UcpNoAdsWikiContextSetup implements DiProcess {
 			window.ads.context && window.ads.context.opts.platformName
 				? window.ads.context.opts.platformName
 				: '';
-		context.set('services.instantConfig.endpoint', 'https://services.fandom.com');
-		context.set('services.instantConfig.appName', platformName);
 
 		if (platformName === 'fandomdesktop') targetingService.set('skin', 'ucp_desktop');
 		else if (platformName === 'fandommobile') targetingService.set('skin', 'ucp_mobile');


### PR DESCRIPTION
## JIRA
https://fandom.atlassian.net/browse/TACO-364

## Description
Thanks to https://github.com/Wikia/pandora/pull/17563 we now have some consistent source of truth for both AdEngine and Identity. This can be used e.g. in determining ICBM endpoint, platform name, etc..