### PR TITLE
COTECH-832 Fix data-vast-position for automated tests in the display+video sync scenario

### DIFF
--- a/spec/core/video/vast-parser.spec.ts
+++ b/spec/core/video/vast-parser.spec.ts
@@ -4,9 +4,12 @@ import { vastParser } from '@wikia/core/video/vast-parser';
 import { expect } from 'chai';
 import { SinonStubbedInstance } from 'sinon';
 
-const dummyVast =
+const dummyVastTagUrl =
 	'dummy.vast?sz=640x480&foo=bar&cust_params=foo1%3Dbar1%26foo2%3Dbar2' +
 	'%26customTitle%3D100%25%20Orange%20Juice%3Dbar2&vpos=preroll';
+
+const dummyVastTagXml =
+	'<?xml version="1.0" encoding="UTF-8"?><VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="4.0">';
 
 function getImaAd(
 	wrapperIds = [],
@@ -47,7 +50,7 @@ describe('vast-parser', () => {
 	});
 
 	it('parse custom parameters from VAST url', () => {
-		const adInfo = vastParser.parse(dummyVast);
+		const adInfo = vastParser.parse(dummyVastTagUrl);
 
 		expect(adInfo.customParams.foo1).to.equal('bar1');
 		expect(adInfo.customParams.foo2).to.equal('bar2');
@@ -55,19 +58,19 @@ describe('vast-parser', () => {
 	});
 
 	it('parse size from VAST url', () => {
-		const adInfo = vastParser.parse(dummyVast);
+		const adInfo = vastParser.parse(dummyVastTagUrl);
 
 		expect(adInfo.size).to.equal('640x480');
 	});
 
 	it('parse position from VAST url', () => {
-		const adInfo = vastParser.parse(dummyVast);
+		const adInfo = vastParser.parse(dummyVastTagUrl);
 
 		expect(adInfo.position).to.equal('preroll');
 	});
 
 	it('current ad info is not set by default', () => {
-		const adInfo = vastParser.parse(dummyVast);
+		const adInfo = vastParser.parse(dummyVastTagUrl);
 
 		expect(adInfo.contentType).to.equal(undefined);
 		expect(adInfo.creativeId).to.equal(undefined);
@@ -75,13 +78,22 @@ describe('vast-parser', () => {
 	});
 
 	it('current ad info from IMA object', () => {
-		const adInfo = vastParser.parse(dummyVast, {
+		const adInfo = vastParser.parse(dummyVastTagUrl, {
 			imaAd: getImaAd(),
 		});
 
 		expect(adInfo.contentType).to.equal('text/javascript');
 		expect(adInfo.creativeId).to.equal('999');
 		expect(adInfo.lineItemId).to.equal('000');
+	});
+
+	it('position from extra.eventAdPosition is mapped properly when VAST is not URL', () => {
+		const adInfo = vastParser.parse(dummyVastTagXml, {
+			imaAd: getImaAd(),
+			eventAdPosition: 'post',
+		});
+
+		expect(adInfo.position).to.equal('postroll');
 	});
 
 	it('current ad info from IMA object', () => {

--- a/src/ad-products/video/jwplayer/streams/jwplayer-stream-state.ts
+++ b/src/ad-products/video/jwplayer/streams/jwplayer-stream-state.ts
@@ -114,6 +114,7 @@ function createVastParams<T extends { payload: JWPlayerEvent }>(): RxJsOperator<
 			map((event: { payload: JWPlayerEvent }) =>
 				vastParser.parse(event.payload.tag, {
 					imaAd: event.payload.ima && event.payload.ima.ad,
+					eventAdPosition: event.payload.adposition,
 				}),
 			),
 		);

--- a/src/core/video/vast-parser.ts
+++ b/src/core/video/vast-parser.ts
@@ -10,6 +10,7 @@ export interface VideoAdInfo {
 
 export interface EventExtra {
 	imaAd?: google.ima.Ad;
+	eventAdPosition?: string;
 }
 
 export interface VastParams {
@@ -20,6 +21,12 @@ export interface VastParams {
 	position: string;
 	size: string;
 }
+
+const eventAdPositionMap = {
+	pre: 'preroll',
+	mid: 'midroll',
+	post: 'postroll',
+};
 
 class VastParser {
 	/**
@@ -74,12 +81,13 @@ class VastParser {
 		return adInfo;
 	}
 
-	parse(vastUrl: string, extra: EventExtra = {}): VastParams {
+	parse(vastTag: string, extra: EventExtra = {}): VastParams {
 		let contentType: string;
 		let creativeId: string;
 		let lineItemId: string;
+		let position: string;
 		const vastParams: Dictionary<string> = queryString.getValues(
-			vastUrl ? vastUrl.substr(1 + vastUrl.indexOf('?')) : '?',
+			vastTag ? vastTag.substr(1 + vastTag.indexOf('?')) : '?',
 		);
 
 		const customParams: Dictionary<string> = queryString.getValues(
@@ -94,12 +102,18 @@ class VastParser {
 			lineItemId = currentAd.lineItemId;
 		}
 
+		if (extra.eventAdPosition && !vastParams.vpos) {
+			position = eventAdPositionMap[extra.eventAdPosition];
+		} else {
+			position = vastParams.vpos;
+		}
+
 		return {
 			contentType,
 			creativeId,
 			customParams,
 			lineItemId,
-			position: vastParams.vpos || 'preroll',
+			position,
 			size: vastParams.sz,
 		};
 	}

--- a/src/core/video/vast-parser.ts
+++ b/src/core/video/vast-parser.ts
@@ -81,6 +81,7 @@ class VastParser {
 		const vastParams: Dictionary<string> = queryString.getValues(
 			vastUrl ? vastUrl.substr(1 + vastUrl.indexOf('?')) : '?',
 		);
+
 		const customParams: Dictionary<string> = queryString.getValues(
 			encodeURI(vastParams.cust_params),
 		);
@@ -98,7 +99,7 @@ class VastParser {
 			creativeId,
 			customParams,
 			lineItemId,
-			position: vastParams.vpos,
+			position: vastParams.vpos || 'preroll',
 			size: vastParams.sz,
 		};
 	}


### PR DESCRIPTION
In the new display+sync implementation we don't send VAST URL to the video player, so it can request GAM for us. We call GAM for a video by ourselves and then pass VAST XML to the player if it's not empty. This implementation however doesn't work well with the vast parser of ours which expects only VAST URL in the `vastTag` variable passed from the player. The parser tries to get from the URL the ad data including video ad "position" (if it's a pre-, mid- or post-roll) but in the new scenario it gets and returns `undefined`.

With this code changes we prioritise data from VAST URL higher but if there is no for example `vpos=preroll` in the URL we reach out to the data passed from the player with the event (`eventAdPosition`).