### PR TITLE
TACO-413 Fix consistency of id5 load time events

### DIFF
--- a/src/ad-bidders/prebid/id5/id5.ts
+++ b/src/ad-bidders/prebid/id5/id5.ts
@@ -34,7 +34,7 @@ class Id5 {
 
 		utils.logger(logGroup, 'enabled');
 		communicationService.emit(eventsRepository.PARTNER_LOAD_STATUS, {
-			status: 'id5_start',
+			status: 'id5_started',
 		});
 
 		const id5AbValue: number = context.get('bidders.prebid.id5AbValue');

--- a/src/ad-bidders/prebid/id5/id5.ts
+++ b/src/ad-bidders/prebid/id5/id5.ts
@@ -1,4 +1,3 @@
-import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { context, targetingService, utils } from '@ad-engine/core';
 import { UserIdConfig } from '../index';
 
@@ -33,9 +32,6 @@ class Id5 {
 		}
 
 		utils.logger(logGroup, 'enabled');
-		communicationService.emit(eventsRepository.PARTNER_LOAD_STATUS, {
-			status: 'id5_started',
-		});
 
 		const id5AbValue: number = context.get('bidders.prebid.id5AbValue');
 		if (id5AbValue) {

--- a/src/ad-bidders/prebid/index.ts
+++ b/src/ad-bidders/prebid/index.ts
@@ -268,7 +268,7 @@ export class PrebidProvider extends BidderProvider {
 
 		id5.enableAnalytics(pbjs);
 		communicationService.emit(eventsRepository.PARTNER_LOAD_STATUS, {
-			status: 'id5_done',
+			status: 'id5_loaded',
 		});
 	}
 
@@ -279,7 +279,7 @@ export class PrebidProvider extends BidderProvider {
 			return;
 		}
 
-		communicationService.emit(eventsRepository.YAHOO_LOADED);
+		communicationService.emit(eventsRepository.YAHOO_STARTED);
 
 		this.prebidConfig.userSync.userIds.push(yahooConnectIdConfig);
 	}

--- a/src/ad-bidders/prebid/index.ts
+++ b/src/ad-bidders/prebid/index.ts
@@ -268,7 +268,7 @@ export class PrebidProvider extends BidderProvider {
 
 		id5.enableAnalytics(pbjs);
 		communicationService.emit(eventsRepository.PARTNER_LOAD_STATUS, {
-			status: 'id5_loaded',
+			status: 'id5_started',
 		});
 	}
 

--- a/src/communication/event-types.ts
+++ b/src/communication/event-types.ts
@@ -228,8 +228,8 @@ export const eventsRepository = {
 	LIVE_CONNECT_RESPONDED_UUID: {
 		name: 'LiveConnect responded with UUID',
 	},
-	YAHOO_LOADED: {
-		name: 'Yahoo loaded',
+	YAHOO_STARTED: {
+		name: 'Yahoo started',
 	},
 	IDENTITY_ENGINE_READY: {
 		category: '[IdentityEngine]',

--- a/src/platforms/shared/tracking/load-times-tracker.ts
+++ b/src/platforms/shared/tracking/load-times-tracker.ts
@@ -12,7 +12,7 @@ const eventsToTrack = {
 	live_connect_responded_uuid: eventsRepository.LIVE_CONNECT_RESPONDED_UUID,
 	a9_without_consents: eventsRepository.A9_WITHOUT_CONSENTS,
 	a9_apstag_hem_sent: eventsRepository.A9_APSTAG_HEM_SENT,
-	yahoo_loaded: eventsRepository.YAHOO_LOADED,
+	yahoo_started: eventsRepository.YAHOO_STARTED,
 };
 
 export class LoadTimesTracker {


### PR DESCRIPTION
### Ticket
https://fandom.atlassian.net/browse/TACO-413

### Description
The naming convention for load time events is `<partner>_started` when the partner has started, and `<partner>_loaded` when the partner is loaded.
In this PR I make ID5 and Yahoo follow this convention.