### PR TITLE
Revert "ADEN-12945: switch to using GTM data to determine page s0 value"

### DIFF
--- a/@types/window/index.d.ts
+++ b/@types/window/index.d.ts
@@ -19,7 +19,6 @@ interface Window {
 	canPlayVideo?: any;
 	cnx?: any;
 	confiant?: Confiant;
-	dataLayer: any;
 	DOMParser: DOMParser;
 	fandomContext: WindowFandomContext;
 	ga?: (
@@ -60,6 +59,7 @@ interface Window {
 	// Fandom JWPlayer sets the sponsored videos list
 	sponsoredVideos?: string[];
 	trackingOptIn?: any;
+	utag_data?: any;
 	wgCookiePath?: string;
 	XMLHttpRequest?: any;
 	optimizely?: {

--- a/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
@@ -1,23 +1,13 @@
 import { GamespotTargetingSetup } from '@wikia/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup';
 import { expect } from 'chai';
 
-class MockDataLayer {
-	events = [];
-	add(event) {
-		this.events.push(event);
-	}
-	find(predicate) {
-		return this.events.find(predicate);
-	}
-}
-
 describe('Gamespot Targeting Setup', () => {
-	beforeEach(() => {
-		window.dataLayer = new MockDataLayer();
+	afterEach(() => {
+		window.utag_data = undefined;
 	});
 
 	describe('getVerticalName', () => {
-		it('returns "gaming" when google_tag_manager is not available', () => {
+		it('returns "gaming" when utag_data is not available', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
 
@@ -28,27 +18,22 @@ describe('Gamespot Targeting Setup', () => {
 			expect(verticalName).to.equal('gaming');
 		});
 
-		it('returns "true" when isEntertainmentSite() receives pathname that includes entertainment', () => {
+		it('returns "ent" when isEnterteinmentSite() returns true', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			global.sandbox.stub(window, 'location').value({
-				pathname: '/entertainment',
-			});
+			window.utag_data = { 'dom.pathname': '/entertainment' };
 
 			//when
-			const isEnt = gamespotTargetingSetup.isEntertainmentSite(window.location.pathname);
+			const verticalName = gamespotTargetingSetup.getVerticalName();
 
 			//then
-			expect(isEnt).to.equal(true);
+			expect(verticalName).to.equal('ent');
 		});
 
 		it('returns "gaming" on siteSection=news when topicName is not available', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'news' },
-			});
+			window.utag_data = { siteSection: 'news' };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -60,10 +45,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "gaming" on siteSection=news when topicName is empty array', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'news' },
-			});
+			window.utag_data = { siteSection: 'news' };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -75,10 +57,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "gaming" on siteSection=news when topicName array include "Games"', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'news', topicName: ['Games'] },
-			});
+			window.utag_data = { siteSection: 'news', topicName: ['Games'] };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -90,10 +69,11 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "gaming" on siteSection=news when topicName does not include "Games" but contentTopicId does', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'news', topicName: ['Tech'], contentTopicName: 'gaming-tech' },
-			});
+			window.utag_data = {
+				siteSection: 'news',
+				topicName: ['Tech'],
+				contentTopicName: 'gaming-tech',
+			};
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -105,10 +85,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "ent" on siteSection=news when topicName array does not include "Games"', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'news', topicName: ['Tech'] },
-			});
+			window.utag_data = { siteSection: 'news', topicName: ['TV'] };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -120,10 +97,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "gaming" on siteSection=reviews when topicName array include "Games"', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'reviews', topicName: ['Games'] },
-			});
+			window.utag_data = { siteSection: 'reviews', topicName: ['Games'] };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -135,10 +109,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "gaming" on siteSection=reviews when topicName array include "Game Review"', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'reviews', topicName: ['Games'] },
-			});
+			window.utag_data = { siteSection: 'reviews', topicName: ['Games'] };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -150,10 +121,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "ent" on siteSection=reviews when topicName array does not include "Games"', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'reviews', topicName: ['TV'] },
-			});
+			window.utag_data = { siteSection: 'reviews', topicName: ['TV'] };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -165,10 +133,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "gaming" on siteSection=galleries when topicName array include "Games"', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'galleries', topicName: ['Games'] },
-			});
+			window.utag_data = { siteSection: 'galleries', topicName: ['Games'] };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -180,10 +145,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "ent" on siteSection=galleries when topicName array does not include "Games"', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'galleries', topicName: ['TV'] },
-			});
+			window.utag_data = { siteSection: 'galleries', topicName: ['TV'] };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -195,10 +157,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "gaming" on siteSection=reviews when topicName is not available', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'news' },
-			});
+			window.utag_data = { siteSection: 'news' };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -210,24 +169,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "gaming" when siteSection does not exist', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: {},
-			});
-
-			//when
-			const verticalName = gamespotTargetingSetup.getVerticalName();
-
-			//then
-			expect(verticalName).to.equal('gaming');
-		});
-
-		it('returns "gaming" when data array is missing in dataLayer', () => {
-			// given
-			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-			});
+			window.utag_data = {};
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();
@@ -239,10 +181,7 @@ describe('Gamespot Targeting Setup', () => {
 		it('returns "gaming" when siteSection is different than news and entertainment', () => {
 			// given
 			const gamespotTargetingSetup = new GamespotTargetingSetup();
-			window.dataLayer.add({
-				event: 'Pageview',
-				data: { siteSection: 'different' },
-			});
+			window.utag_data = { siteSection: 'different' };
 
 			//when
 			const verticalName = gamespotTargetingSetup.getVerticalName();

--- a/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
@@ -1,26 +1,13 @@
 import { MetacriticTargetingSetup } from '@wikia/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup';
 import { expect } from 'chai';
 
-class MockDataLayer {
-	events = [];
-	add(event) {
-		this.events.push(event);
-	}
-	find(predicate) {
-		return this.events.find(predicate);
-	}
-}
-
 describe('Metacritic Targeting Setup', () => {
-	beforeEach(() => {
-		window.dataLayer = new MockDataLayer();
+	afterEach(() => {
+		window.utag_data = undefined;
 	});
 
 	it('getVerticalName() returns "gaming" on gaming section sites', () => {
-		window.dataLayer.add({
-			event: 'Pageview',
-			data: { siteSection: 'games' },
-		});
+		window.utag_data = { siteSection: 'games' };
 
 		const verticalName = new MetacriticTargetingSetup().getVerticalName();
 
@@ -28,52 +15,23 @@ describe('Metacritic Targeting Setup', () => {
 	});
 
 	it('getVerticalName() returns "ent" on section sites different than gaming', () => {
-		window.dataLayer.add({
-			event: 'Pageview',
-			data: { siteSection: 'movies' },
-		});
+		window.utag_data = { siteSection: 'movies' };
 
 		const verticalName = new MetacriticTargetingSetup().getVerticalName();
 
 		expect(verticalName).to.equal('ent');
 	});
 
-	it('getVerticalName() returns "ent" when data is missing from the dataLayer', () => {
-		window.dataLayer.add({
-			event: 'Pageview',
-		});
-
-		const verticalName = new MetacriticTargetingSetup().getVerticalName();
-
-		expect(verticalName).to.equal('ent');
-	});
-
-	it('getPageType() returns correct pageType from dataLayer', () => {
-		window.dataLayer.add({
-			event: 'Pageview',
-			data: { pageType: 'article' },
-		});
+	it('getPageType() returns correct pageType from utag_data', () => {
+		window.utag_data = { pageType: 'article' };
 
 		const ptype = new MetacriticTargetingSetup().getPageType();
 
 		expect(ptype).to.equal('article');
 	});
 
-	it('getPageType() returns undefined when pageType is missing from dataLayer', () => {
-		window.dataLayer.add({
-			event: 'Pageview',
-			data: { siteType: 'article' },
-		});
-
-		const ptype = new MetacriticTargetingSetup().getPageType();
-
-		expect(ptype).to.be.undefined;
-	});
-
-	it('getPageType() returns undefined when data is missing from dataLayer', () => {
-		window.dataLayer.add({
-			event: 'Pageview',
-		});
+	it('getPageType() returns undefined when pageType is missing from utag_data', () => {
+		window.utag_data = { siteType: 'article' };
 
 		const ptype = new MetacriticTargetingSetup().getPageType();
 

--- a/spec/platforms/news-and-ratings/shared/context/base/news-and-ratings-base-context.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/shared/context/base/news-and-ratings-base-context.setup.spec.ts
@@ -88,8 +88,8 @@ describe('News and Ratings base context setup', () => {
 				'getDataSettingsFromMetaTag',
 			);
 			getDataSettingsFromMetaTagStub.returns(null);
-			const getGtagDataStub = global.sandbox.stub(baseContextSetup, 'getGtagData');
-			getGtagDataStub.returns({ event: 'Pageview', data: { siteSection: 'home' } });
+			const getUtagDataStub = global.sandbox.stub(baseContextSetup, 'getUtagData');
+			getUtagDataStub.returns({ siteSection: 'home' });
 
 			baseContextSetup.execute();
 
@@ -103,38 +103,38 @@ describe('News and Ratings base context setup', () => {
 				'getDataSettingsFromMetaTag',
 			);
 			getDataSettingsFromMetaTagStub.returns({ foo: 'bar' });
-			const getGtagDataStub = global.sandbox.stub(baseContextSetup, 'getGtagData');
-			getGtagDataStub.returns({ event: 'Pageview', data: { siteSection: 'home' } });
+			const getUtagDataStub = global.sandbox.stub(baseContextSetup, 'getUtagData');
+			getUtagDataStub.returns({ siteSection: 'home' });
 
 			baseContextSetup.execute();
 
 			expect(context.get('custom.pagePath')).to.eq('/home');
 		});
 
-		it('sets proper page path based - incorrect ad-settings meta tag and no data from gtag data', () => {
+		it('sets proper page path based - incorrect ad-settings meta tag and no data from utag data', () => {
 			const baseContextSetup = new NewsAndRatingsBaseContextSetup(instantConfigStub);
 			const getDataSettingsFromMetaTagStub = global.sandbox.stub(
 				baseContextSetup,
 				'getDataSettingsFromMetaTag',
 			);
 			getDataSettingsFromMetaTagStub.returns(null);
-			const getGtagDataStub = global.sandbox.stub(baseContextSetup, 'getGtagData');
-			getGtagDataStub.returns({});
+			const getUtagDataStub = global.sandbox.stub(baseContextSetup, 'getUtagData');
+			getUtagDataStub.returns({});
 
 			baseContextSetup.execute();
 
 			expect(context.get('custom.pagePath')).to.eq('');
 		});
 
-		it('sets proper page path based - incorrect ad-settings meta tag and no gtag', () => {
+		it('sets proper page path based - incorrect ad-settings meta tag and no utag', () => {
 			const baseContextSetup = new NewsAndRatingsBaseContextSetup(instantConfigStub);
 			const getDataSettingsFromMetaTagStub = global.sandbox.stub(
 				baseContextSetup,
 				'getDataSettingsFromMetaTag',
 			);
 			getDataSettingsFromMetaTagStub.returns(null);
-			const getGtagDataStub = global.sandbox.stub(baseContextSetup, 'getGtagData');
-			getGtagDataStub.returns(undefined);
+			const getUtagDataStub = global.sandbox.stub(baseContextSetup, 'getUtagData');
+			getUtagDataStub.returns(undefined);
 
 			baseContextSetup.execute();
 

--- a/src/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.ts
@@ -14,21 +14,21 @@ export class GamespotTargetingSetup implements DiProcess {
 	}
 
 	getVerticalName(): 'gaming' | 'ent' {
-		const gtagData = window.dataLayer.find(({ event }) => event === 'Pageview');
-		const pathname = window.location.pathname;
-
-		if (!gtagData || !gtagData.data) {
+		const utagData = window.utag_data;
+		if (!utagData) {
 			return 'gaming';
 		}
 
-		if (this.isEntertainmentSite(pathname)) {
+		if (this.isEntertainmentSite(utagData['dom.pathname'])) {
 			return 'ent';
 		}
 
-		const validSiteSections = ['news', 'reviews', 'galleries'];
-
-		if (validSiteSections.includes(gtagData.data.siteSection)) {
-			return this.getVerticalNameBasedOnTopicName(gtagData);
+		if (
+			utagData.siteSection === 'news' ||
+			utagData.siteSection === 'reviews' ||
+			utagData.siteSection === 'galleries'
+		) {
+			return this.getVerticalNameBasedOnTopicName(utagData);
 		}
 
 		return 'gaming';
@@ -42,9 +42,9 @@ export class GamespotTargetingSetup implements DiProcess {
 		return pathname.includes('entertainment');
 	}
 
-	private getVerticalNameBasedOnTopicName(gtagData): 'gaming' | 'ent' {
-		const topicName = gtagData.data.topicName;
-		const contentTopicName = gtagData.data.contentTopicName;
+	private getVerticalNameBasedOnTopicName(utagData): 'gaming' | 'ent' {
+		const topicName = utagData.topicName;
+		const contentTopicName = utagData.contentTopicName;
 
 		if (!Array.isArray(topicName) || topicName.length === 0) {
 			return 'gaming';

--- a/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.ts
@@ -13,12 +13,10 @@ export class MetacriticTargetingSetup implements DiProcess {
 	}
 
 	getVerticalName(): 'gaming' | 'ent' {
-		const gtagData = window.dataLayer.find(({ event }) => event === 'Pageview');
-		return gtagData?.data?.siteSection === 'games' ? 'gaming' : 'ent';
+		return window.utag_data?.siteSection === 'games' ? 'gaming' : 'ent';
 	}
 
 	getPageType(): string | undefined {
-		const gtagData = window.dataLayer.find(({ event }) => event === 'Pageview');
-		return gtagData?.data?.pageType;
+		return window.utag_data?.pageType;
 	}
 }

--- a/src/platforms/news-and-ratings/shared/setup/context/base/news-and-ratings-base-context.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/context/base/news-and-ratings-base-context.setup.ts
@@ -113,7 +113,7 @@ export class NewsAndRatingsBaseContextSetup implements DiProcess {
 		const dataWithPagePath = this.getDataSettingsFromMetaTag();
 		const pagePath = dataWithPagePath?.unit_name
 			? this.getPagePathFromMetaTagData(dataWithPagePath)
-			: this.getPagePathFromGtagData();
+			: this.getPagePathFromUtagData();
 
 		if (!pagePath) {
 			return '';
@@ -130,9 +130,9 @@ export class NewsAndRatingsBaseContextSetup implements DiProcess {
 		return slicedUnitName.replace(adUnitPropertyPart, '');
 	}
 
-	private getPagePathFromGtagData() {
-		const dataWithPagePath = this.getGtagData();
-		return dataWithPagePath?.data?.siteSection;
+	private getPagePathFromUtagData() {
+		const dataWithPagePath = this.getUtagData();
+		return dataWithPagePath?.siteSection;
 	}
 
 	getDataSettingsFromMetaTag() {
@@ -151,10 +151,10 @@ export class NewsAndRatingsBaseContextSetup implements DiProcess {
 		}
 	}
 
-	getGtagData() {
-		const gtagData = window.dataLayer.find(({ event }) => event === 'Pageview');
-		this.log('tag data: ', gtagData);
-		return gtagData;
+	getUtagData() {
+		const utagData = window.utag_data;
+		this.log('utag data: ', utagData);
+		return utagData;
 	}
 
 	private log(...logValues) {

--- a/src/platforms/news-and-ratings/shared/setup/context/targeting/news-and-ratings-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/context/targeting/news-and-ratings-targeting.setup.ts
@@ -111,13 +111,12 @@ export class NewsAndRatingsTargetingSetup implements DiProcess {
 	}
 
 	getViewGuid() {
-		const pageViewGuid = this.getViewGuidFromGtagData() || this.getViewGuidFromMetaTag();
+		const pageViewGuid = this.getViewGuidFromUtagData() || this.getViewGuidFromMetaTag();
 		return { vguid: pageViewGuid };
 	}
 
-	getViewGuidFromGtagData() {
-		const tagData = window.dataLayer.find(({ event }) => event === 'Pageview');
-		return tagData?.pageview_id;
+	getViewGuidFromUtagData() {
+		return window.utag_data?.pageViewGuid;
 	}
 
 	getViewGuidFromMetaTag() {


### PR DESCRIPTION
Regression tests failed to pass so reverting this to keep dev clean.

Reverts Wikia/ad-engine#2311