### PR TITLE
COTECH-1084 Fix JS error in the console connected to incontent video

### DIFF
--- a/src/ad-services/connatix/index.ts
+++ b/src/ad-services/connatix/index.ts
@@ -79,10 +79,12 @@ export class Connatix extends BaseServiceSetup {
 
 		utils.logger(logGroup, 'initialized', this.cid);
 
-		communicationService.on(
-			eventsRepository.AD_ENGINE_UAP_LOAD_STATUS,
-			this.loadOnUapStatus.bind(this),
-		);
+		if (context.get('custom.hasIncontentPlayer')) {
+			communicationService.on(
+				eventsRepository.AD_ENGINE_UAP_LOAD_STATUS,
+				this.loadOnUapStatus.bind(this),
+			);
+		}
 	}
 
 	private loadOnUapStatus({ isLoaded, adProduct }: UapLoadStatus) {


### PR DESCRIPTION
With the changes in this PR we stop injecting incontent video on pages with featured video for Connatix. This way there is no JS error in the console: `Cannot read properties of null (reading 'appendChild')`.

The `custom.hasIncontentPlayer` flag is being set in the AdEngine when there is no featured video: https://github.com/Wikia/ad-engine/blob/bacb10abe892e49b7fc4f5bcfbb72c999af02fa2/src/platforms/shared/context/targeting/targeting-strategies/providers/common-tags.ts#L56-L62