### PR TITLE
COTECH-1083 | tagless request indicator

### DIFF
--- a/src/ad-products/video/jwplayer/helpers/vast-tagless-request.ts
+++ b/src/ad-products/video/jwplayer/helpers/vast-tagless-request.ts
@@ -39,6 +39,7 @@ export class VastTaglessRequest {
 		return utils.buildVastUrl(aspectRatio, slotName, {
 			vpos: position,
 			targeting: biddersTargeting,
+			isTagless: true,
 		});
 	}
 

--- a/src/core/utils/tagless-request-url-builder.ts
+++ b/src/core/utils/tagless-request-url-builder.ts
@@ -19,6 +19,7 @@ export interface VastOptions {
 	videoId: string;
 	numberOfAds: number;
 	vpos: string;
+	isTagless: boolean;
 }
 
 const availableVideoPositions: string[] = ['preroll', 'midroll', 'postroll'];
@@ -137,6 +138,10 @@ export function buildVastUrl(
 	}
 
 	params.push(`rdp=${trackingOptIn.isOptOutSale() ? 1 : 0}`);
+
+	if (options.isTagless) {
+		params.push('tagless=1');
+	}
 
 	return vastBaseUrl + params.join('&');
 }


### PR DESCRIPTION
For e2e testing we need a way to differentiate tagless requests from regular vast requests - we did it by adding extra query parameter - `tagless=1`