### PR TITLE
COTECH-1074 Run jwpManager.manage() only for legacy JWP

### DIFF
--- a/src/platforms/shared/setup/player.setup.ts
+++ b/src/platforms/shared/setup/player.setup.ts
@@ -63,8 +63,6 @@ export class PlayerSetup extends BaseServiceSetup {
 			utils.logger(logGroup, 'display and video sync response available');
 		}
 
-		this.jwpManager.manage();
-
 		if (showAds && !strategyRulesEnabled) {
 			communicationService.dispatch(
 				jwpSetup({
@@ -73,12 +71,12 @@ export class PlayerSetup extends BaseServiceSetup {
 					vastXml: vastResponse?.xml,
 				}),
 			);
+			this.jwpManager.manage();
 		} else if (strategyRulesEnabled) {
 			utils.logger(
 				logGroup,
 				'JWP Strategy Rules enabled - AdEngine does not control ads in JWP anymore',
 			);
-			this.jwpManager.manage();
 			communicationService.dispatch(
 				jwpSetup({
 					showAds,


### PR DESCRIPTION
There are ExCo/ShowHereos/Outbrain players being loaded with JWP strategy rules which throws JS errors in the dev console. The errors are coming from the jwpManager which should only work with legacy JWP, so the changes in this PR should fix it.