### PR TITLE
TACO-447 Save ID5 AB testing control group to local storage

### DIFF
--- a/spec/ad-bidders/prebid/id5/id5.spec.ts
+++ b/spec/ad-bidders/prebid/id5/id5.spec.ts
@@ -25,6 +25,7 @@ describe('Id5', () => {
 
 	beforeEach(() => {
 		context.set('bidders.prebid.id5', true);
+		context.set('options.trackingOptIn', true);
 		context.set('options.optOutSale', false);
 		window.fandomContext.partners.directedAtChildren = false;
 
@@ -50,7 +51,13 @@ describe('Id5', () => {
 		expect(id5.getConfig()).to.eql(undefined);
 	});
 
-	it('Id5 is disabled if user has opted out sale', () => {
+	it('Id5 is disabled if user has opted out sale in GDPR', () => {
+		context.set('options.trackingOptIn', false);
+
+		expect(id5.getConfig()).to.eql(undefined);
+	});
+
+	it('Id5 is disabled if user has opted out sale in US', () => {
 		context.set('options.optOutSale', true);
 
 		expect(id5.getConfig()).to.eql(undefined);

--- a/src/ad-bidders/prebid/id5/id5.ts
+++ b/src/ad-bidders/prebid/id5/id5.ts
@@ -1,4 +1,4 @@
-import { context, targetingService, utils } from '@ad-engine/core';
+import { context, targetingService, UniversalStorage, utils } from '@ad-engine/core';
 import { UserIdConfig } from '../index';
 
 interface Id5Config extends UserIdConfig {
@@ -15,7 +15,12 @@ const logGroup = 'Id5';
 
 class Id5 {
 	private partnerId = 1139;
+	private storage;
 	private id5GroupKey = 'id5_group';
+
+	constructor() {
+		this.storage = new UniversalStorage();
+	}
 
 	private isEnabled(): boolean {
 		return (
@@ -67,11 +72,15 @@ class Id5 {
 	}
 
 	async trackControlGroup(pbjs: Pbjs): Promise<void> {
-		const controlGroup = await this.getControlGroup(pbjs);
+		const controlGroup = this.getControlGroupFromStorage() || (await this.getControlGroup(pbjs));
 
 		utils.logger(logGroup, 'Control group', controlGroup);
 
 		this.setTargeting(this.id5GroupKey, controlGroup);
+
+		if (controlGroup && controlGroup !== 'U') {
+			this.saveInStorage(this.id5GroupKey, controlGroup);
+		}
 	}
 
 	public async getControlGroup(pbjs: Pbjs): Promise<id5GroupValue> {
@@ -87,6 +96,24 @@ class Id5 {
 		}
 
 		return isUserInControlGroup === true ? 'B' : 'A';
+	}
+
+	private getControlGroupFromStorage(): id5GroupValue {
+		const storageValue = this.storage.getItem(this.id5GroupKey);
+
+		if (storageValue !== null) {
+			utils.logger(logGroup, 'Control group found in the storage', storageValue);
+			return storageValue;
+		}
+	}
+
+	private saveInStorage(key: string, value: string) {
+		if (this.storage.getItem(key) !== null) {
+			return;
+		}
+
+		this.storage.setItem(this.id5GroupKey, value);
+		utils.logger(logGroup, key, 'saved in storage', value);
 	}
 
 	private setTargeting(key: string, value: string): void {

--- a/src/ad-bidders/prebid/id5/id5.ts
+++ b/src/ad-bidders/prebid/id5/id5.ts
@@ -25,6 +25,7 @@ class Id5 {
 	private isEnabled(): boolean {
 		return (
 			context.get('bidders.prebid.id5') &&
+			context.get('options.trackingOptIn') &&
 			!context.get('options.optOutSale') &&
 			!utils.isCoppaSubject()
 		);


### PR DESCRIPTION
### Ticket
https://fandom.atlassian.net/browse/TACO-447

### Description

The `abTestingControlGroup` in `pbjs.getUserIds()?.id5id?.ext?.abTestingControlGroup` is the object that we take the information about whether the user is in A/B testing control group. Then we send this information to GAM with a key val.

ID5 changed their API and  `abTestingControlGroup` is available only on the first page view.

In this PR I've added saving of `abTestingControlGroup` to local storage, so it is available on every page view.