### PR TITLE
Optimize QueryString util class

### DIFF
--- a/spec/core/utils/query-string.spec.ts
+++ b/spec/core/utils/query-string.spec.ts
@@ -2,42 +2,6 @@ import { queryString } from '@wikia/core/utils';
 import { expect } from 'chai';
 
 describe('query-string', () => {
-	describe('parseValue', () => {
-		it('parse truthy boolean value from string', () => {
-			expect(queryString.parseValue('true')).to.equal(true);
-		});
-
-		it('parse falsy boolean value from string', () => {
-			expect(queryString.parseValue('false')).to.equal(false);
-		});
-
-		it('parse number value from string', () => {
-			expect(queryString.parseValue('123')).to.equal(123);
-		});
-
-		it('parse numbers array value from string', () => {
-			expect(queryString.parseValue('[4,8,15,16,23,42]')).to.deep.equal([4, 8, 15, 16, 23, 42]);
-		});
-
-		it('parse string value from string', () => {
-			expect(queryString.parseValue('foo')).to.equal('foo');
-		});
-
-		it('parse strings array value from string', () => {
-			expect(queryString.parseValue('["foo","bar"]')).to.deep.equal(['foo', 'bar']);
-		});
-
-		it('parse json value from string', () => {
-			expect(queryString.parseValue('{"this":{"is":"json"}}')).to.deep.equal({
-				this: { is: 'json' },
-			});
-		});
-
-		it('parse null from empty string', () => {
-			expect(queryString.parseValue('')).to.equal(null);
-		});
-	});
-
 	describe('isUrlParamSet', () => {
 		beforeEach(() => {
 			global.sandbox.stub(window, 'location').value({ search: '?first=1&second' });

--- a/spec/core/video/vast-parser.spec.ts
+++ b/spec/core/video/vast-parser.spec.ts
@@ -54,7 +54,7 @@ describe('vast-parser', () => {
 
 		expect(adInfo.customParams.foo1).to.equal('bar1');
 		expect(adInfo.customParams.foo2).to.equal('bar2');
-		expect(adInfo.customParams.customTitle).to.equal('100% Orange Juice');
+		expect(adInfo.customParams.customTitle).to.equal('100% Orange Juice=bar2');
 	});
 
 	it('parse size from VAST url', () => {

--- a/src/core/utils/query-string.ts
+++ b/src/core/utils/query-string.ts
@@ -3,7 +3,7 @@ class QueryString {
 
 	getValues(input?: string): Record<string, string> {
 		return [...this.getURLSearchParams(input).entries()].reduce((acc, [key, value]) => {
-			acc[key] = decodeURIComponent(value.replace(/\+/g, ' '));
+			acc[key] = value;
 			return acc;
 		}, {});
 	}

--- a/src/core/utils/query-string.ts
+++ b/src/core/utils/query-string.ts
@@ -1,59 +1,33 @@
-import { Dictionary } from '../models';
-
-type QueryValue = boolean | string | string[] | number | number[] | object | null;
-
 class QueryString {
-	getValues(input?: string): Dictionary<string> {
-		const path: string = input || window.location.search.substring(1);
-		const queryStringParameters: string[] = path.split('&');
-		const queryParameters: Dictionary<string> = {};
+	private readonly cache = new Map<string, URLSearchParams>();
 
-		queryStringParameters.forEach((pair) => {
-			const [id, value] = pair.split('=');
-
-			if (value) {
-				queryParameters[id] = decodeURIComponent(value.replace(/\+/g, ' '));
-			}
-		});
-
-		return queryParameters;
+	getValues(input?: string): Record<string, string> {
+		return [...this.getURLSearchParams(input).entries()].reduce((acc, [key, value]) => {
+			acc[key] = decodeURIComponent(value.replace(/\+/g, ' '));
+			return acc;
+		}, {});
 	}
 
 	getURLSearchParams(input?: string): URLSearchParams {
 		const path: string = input || window.location.search.substring(1);
 
-		return new URLSearchParams(path);
+		if (!this.cache.has(path)) {
+			this.cache.set(path, new URLSearchParams(path));
+		}
+
+		return this.cache.get(path);
 	}
 
 	get(key: string): string {
-		const queryParameters = this.getValues();
-
-		return queryParameters[key];
+		return this.getURLSearchParams().get(key) || '';
 	}
 
 	isUrlParamSet(param: string): boolean {
 		return !!parseInt(this.get(param), 10);
 	}
 
-	parseValue(value: string): QueryValue {
-		if (value === 'true' || value === 'false') {
-			return value === 'true';
-		}
-
-		const intValue = parseInt(value, 10);
-		if (value === `${intValue}`) {
-			return intValue;
-		}
-
-		try {
-			return JSON.parse(value);
-		} catch (ignore) {
-			return value || null;
-		}
-	}
-
-	stringify(params: object): string {
-		const queryParams = new URLSearchParams(params as Dictionary<string>);
+	stringify(params: Record<string, string>): string {
+		const queryParams = new URLSearchParams(params);
 		queryParams.sort();
 
 		return queryParams.toString();

--- a/src/core/video/vast-parser.ts
+++ b/src/core/video/vast-parser.ts
@@ -89,10 +89,7 @@ class VastParser {
 		const vastParams: Dictionary<string> = queryString.getValues(
 			vastTag ? vastTag.substr(1 + vastTag.indexOf('?')) : '?',
 		);
-
-		const customParams: Dictionary<string> = queryString.getValues(
-			encodeURI(vastParams.cust_params),
-		);
+		const customParams: Dictionary<string> = queryString.getValues(vastParams.cust_params);
 
 		if (extra.imaAd) {
 			const currentAd = this.getAdInfo(extra.imaAd);

--- a/src/platforms/shared/tracking/data-warehouse.ts
+++ b/src/platforms/shared/tracking/data-warehouse.ts
@@ -163,7 +163,7 @@ export class DataWarehouseTracker {
 			utils.logger(logGroup, msg);
 			throw new Error(msg);
 		}
-		return `${baseUrl}?${utils.queryString.stringify(params)}`;
+		return `${baseUrl}?${utils.queryString.stringify(params as unknown as Record<string, string>)}`;
 	}
 
 	/**


### PR DESCRIPTION
Cache the most heavy computation - URL query string parsing. Remove `parseValue` method that is being unused and simplify VAST URL parsing.

Fun fact: there was an error in previously implemented logic that resulted in missing `=bar2` in one of the VAST parser test cases. Quite an exotic edge case I must admit that will probably never happen in real traffic :)