### PR TITLE
Introduce strict mode with typescript-strict-plugin

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,6 +24,8 @@ jobs:
             ${{ runner.os }}-npm-
       - name: Install dependencies
         run: npm ci
+      - name: Types check
+        run: npm run tsc
       - name: Run coverage
         run: npm run test-coverage
       - name: Upload coverage to Codecov

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
 				"tsconfig-paths-webpack-plugin": "4.0.1",
 				"tslib": "2.5.0",
 				"typescript": "4.9.5",
+				"typescript-strict-plugin": "2.4.0",
 				"webpack": "5.76.0",
 				"webpack-bundle-analyzer": "4.8.0",
 				"webpack-cli": "5.0.1",
@@ -3703,6 +3704,15 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.4.0"
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -9894,6 +9904,16 @@
 			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
+		"node_modules/pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -11833,6 +11853,232 @@
 			},
 			"engines": {
 				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/typescript-strict-plugin": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/typescript-strict-plugin/-/typescript-strict-plugin-2.4.0.tgz",
+			"integrity": "sha512-lnahT7Fl83WUaTqXPRD4e/qdtY8iQjgKtbkkC4cHuhjocQNThiG9qqDuuv8PofAj1pBQv+cTXVmIB3wavl72tg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^3.0.0",
+				"execa": "^4.0.0",
+				"minimatch": "^9.0.3",
+				"ora": "^5.4.1",
+				"yargs": "^16.2.0"
+			},
+			"bin": {
+				"tsc-strict": "dist/cli/tsc-strict/index.js",
+				"update-strict-comments": "dist/cli/update-strict-comments/index.js"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/typescript-strict-plugin/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/typescript-strict-plugin/node_modules/execa": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"get-stream": "^5.0.0",
+				"human-signals": "^1.1.1",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.0",
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/human-signals": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.12.0"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/typescript-strict-plugin/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/uniq": {
@@ -15674,6 +15920,15 @@
 						"safer-buffer": ">= 2.1.2 < 3.0.0"
 					}
 				}
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -20374,6 +20629,16 @@
 			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -21903,6 +22168,173 @@
 			"version": "4.9.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
 			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+		},
+		"typescript-strict-plugin": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/typescript-strict-plugin/-/typescript-strict-plugin-2.4.0.tgz",
+			"integrity": "sha512-lnahT7Fl83WUaTqXPRD4e/qdtY8iQjgKtbkkC4cHuhjocQNThiG9qqDuuv8PofAj1pBQv+cTXVmIB3wavl72tg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^3.0.0",
+				"execa": "^4.0.0",
+				"minimatch": "^9.0.3",
+				"ora": "^5.4.1",
+				"yargs": "^16.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"execa": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"human-signals": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+					"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"is-stream": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+					"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "9.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+					"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"yargs": {
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
+				}
+			}
 		},
 		"uniq": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"tsconfig-paths-webpack-plugin": "4.0.1",
 		"tslib": "2.5.0",
 		"typescript": "4.9.5",
+		"typescript-strict-plugin": "2.4.0",
 		"webpack": "5.76.0",
 		"webpack-bundle-analyzer": "4.8.0",
 		"webpack-cli": "5.0.1",
@@ -78,7 +79,8 @@
 		"preversion": "./maintenance/preversion.sh",
 		"test": "instant-mocha './spec/**/*.spec.ts' -r jsdom-global/register --webpack-config webpack.common.js --require ./spec/helpers/sandbox-hook.js",
 		"test:watch": "npm run test -- -w",
-		"test-coverage": "nyc instant-mocha './src/!(platforms)*/**/*.ts' './src/platforms/shared/**/*.ts' './spec/**/*.spec.ts' -r jsdom-global/register --webpack-config webpack.coverage.js --require ./spec/helpers/sandbox-hook.js"
+		"test-coverage": "nyc instant-mocha './src/!(platforms)*/**/*.ts' './src/platforms/shared/**/*.ts' './spec/**/*.spec.ts' -r jsdom-global/register --webpack-config webpack.coverage.js --require ./spec/helpers/sandbox-hook.js",
+		"tsc": "tsc --noEmit && tsc-strict"
 	},
 	"lint-staged": {
 		"*.ts": [

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"dev:platforms": "webpack-dev-server --progress --config webpack.platforms.js --mode=development",
 		"dev-https:platforms": "npm run dev:platforms -- --server-type https",
 		"bundle-analyzer": "npm run build:platforms -- --env bundleAnalyzer",
-		"ci-check": "npm run test && npm run lint",
+		"ci-check": "npm run test && npm run lint && npm run tsc",
 		"lint": "npx eslint . --ext .ts --max-warnings 0",
 		"format": "npm run prettier",
 		"graph": "madge --image graph.svg --extensions ts --webpack-config webpack.platforms.js --ts-config tsconfig.json src/",

--- a/spec/ad-bidders/index.spec.ts
+++ b/spec/ad-bidders/index.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Bidders } from '@wikia/ad-bidders';
 import { A9Provider } from '@wikia/ad-bidders/a9';
 import { PrebidProvider } from '@wikia/ad-bidders/prebid';

--- a/spec/ad-bidders/prebid/native/prebid-native-config.spec.ts
+++ b/spec/ad-bidders/prebid/native/prebid-native-config.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PrebidNativeConfig } from '@wikia/ad-bidders';
 import { expect } from 'chai';
 

--- a/spec/ad-bidders/prebid/prebid-settings.spec.ts
+++ b/spec/ad-bidders/prebid/prebid-settings.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createAdapterSpecificSettings } from '@wikia/ad-bidders/prebid/prebid-settings';
 import { expect } from 'chai';
 

--- a/spec/ad-products/video/jwplayer/helpers/jwplayer-helper-skipping-sponsored-video.spec.ts
+++ b/spec/ad-products/video/jwplayer/helpers/jwplayer-helper-skipping-sponsored-video.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { expect } from 'chai';
 
 import { JwplayerHelperSkippingSponsoredVideo } from '@wikia/ad-products/video/jwplayer/helpers';

--- a/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
+++ b/spec/ad-products/video/jwplayer/helpers/jwplayer-helper.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { expect } from 'chai';
 
 import { JWPlayerConfig } from '@wikia/ad-products/video/jwplayer/external-types/jwplayer-config';

--- a/spec/ad-products/video/jwplayer/streams/jwplayer-stream-stateless.spec.ts
+++ b/spec/ad-products/video/jwplayer/streams/jwplayer-stream-stateless.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { jwpEvents } from '@wikia/ad-products/video/jwplayer/streams/jwplayer-events';
 import { ofJwpEvent } from '@wikia/ad-products/video/jwplayer/streams/jwplayer-stream';
 import { createJwpStatelessStream } from '@wikia/ad-products/video/jwplayer/streams/jwplayer-stream-stateless';

--- a/spec/ad-products/video/jwplayer/streams/jwplayer-stream.spec.ts
+++ b/spec/ad-products/video/jwplayer/streams/jwplayer-stream.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { jwpEvents } from '@wikia/ad-products/video/jwplayer/streams/jwplayer-events';
 import {
 	createJwpStream,

--- a/spec/ad-services/experian/experian.spec.ts
+++ b/spec/ad-services/experian/experian.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Experian } from '@wikia/ad-services';
 import { context, InstantConfigService } from '@wikia/core';
 import { expect } from 'chai';

--- a/spec/ad-services/ias-publisher-optimization/ias-publisher-optimization.spec.ts
+++ b/spec/ad-services/ias-publisher-optimization/ias-publisher-optimization.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { IasPublisherOptimization } from '@wikia/ad-services';
 import {
 	context,

--- a/spec/ad-services/live-connect/live-connect.spec.ts
+++ b/spec/ad-services/live-connect/live-connect.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LiveConnect } from '@wikia/ad-services';
 import { communicationService, eventsRepository } from '@wikia/communication';
 import { context, InstantConfigService, utils } from '@wikia/core';

--- a/spec/ad-services/open-web/open-web.spec.ts
+++ b/spec/ad-services/open-web/open-web.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { OpenWeb, PlacementsBuilder, PlacementsHandler } from '@wikia/ad-services';
 import { communicationService, EventOptions } from '@wikia/communication';
 import { context, InstantConfigService, utils } from '@wikia/core';

--- a/spec/core/ad-slot-fake.ts
+++ b/spec/core/ad-slot-fake.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@wikia/communication';
 
 const dataset = {};

--- a/spec/core/listeners/porvata-listener.spec.ts
+++ b/spec/core/listeners/porvata-listener.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	PorvataListener,
 	PorvataListenerParams,

--- a/spec/core/pipeline/imps/func-pipeline.spec.ts
+++ b/spec/core/pipeline/imps/func-pipeline.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { FuncPipeline, FuncPipelineStep } from '@wikia/core';
 import { PipelineTestSuite } from './pipeline-test-suite';
 

--- a/spec/core/pipeline/imps/universal-pipeline.spec.ts
+++ b/spec/core/pipeline/imps/universal-pipeline.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	DiPipelineStep,
 	FuncPipelineStep,

--- a/spec/core/providers/nativo/nativo-provider.spec.ts
+++ b/spec/core/providers/nativo/nativo-provider.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { NativoProvider } from '@wikia/core/providers/nativo/nativo-provider';
 import { expect } from 'chai';
 import { adSlotFake } from '../../ad-slot-fake';

--- a/spec/core/providers/nativo/nativo.spec.ts
+++ b/spec/core/providers/nativo/nativo.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { expect } from 'chai';
 import { spy } from 'sinon';
 

--- a/spec/core/providers/prebidium-provider.spec.ts
+++ b/spec/core/providers/prebidium-provider.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@wikia/communication';
 import { PrebidiumProvider, targetingService } from '@wikia/core';
 import { IframeBuilder } from '@wikia/core/utils';

--- a/spec/core/services/message-bus.spec.ts
+++ b/spec/core/services/message-bus.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { expect } from 'chai';
 import { SinonSpy, SinonStub } from 'sinon';
 

--- a/spec/core/services/slot-creator.spec.ts
+++ b/spec/core/services/slot-creator.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { SlotCreator, SlotCreatorConfig, SlotCreatorWrapperConfig } from '@wikia/core';
 import { expect } from 'chai';
 import { SinonStub } from 'sinon';

--- a/spec/core/services/slot-placeholder-injector.spec.ts
+++ b/spec/core/services/slot-placeholder-injector.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	RepeatableSlotPlaceholderConfig,
 	SlotPlaceholderConfig,

--- a/spec/core/services/slot-service.spec.ts
+++ b/spec/core/services/slot-service.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	context,
 	Dictionary,

--- a/spec/core/services/slot-tweaker.spec.ts
+++ b/spec/core/services/slot-tweaker.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { SlotTweaker } from '@wikia/core/services/slot-tweaker';
 import { expect } from 'chai';
 import { adSlotFake } from '../ad-slot-fake';

--- a/spec/core/services/templates-registry/template-machine.spec.ts
+++ b/spec/core/services/templates-registry/template-machine.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TemplateAction } from '@wikia/core/services/templates-registry/template-action';
 import { TemplateMachine } from '@wikia/core/services/templates-registry/template-machine';
 import { assert, expect } from 'chai';

--- a/spec/core/services/templates-registry/template-state.spec.ts
+++ b/spec/core/services/templates-registry/template-state.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TemplateTransition } from '@wikia/core';
 import { TemplateState } from '@wikia/core/services/templates-registry/template-state';
 import { assert, expect } from 'chai';

--- a/spec/core/utils/iframe-builder.spec.ts
+++ b/spec/core/utils/iframe-builder.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { IframeBuilder } from '@wikia/core/utils';
 import { assert } from 'chai';
 

--- a/spec/core/utils/promised-timeout.spec.ts
+++ b/spec/core/utils/promised-timeout.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { utils } from '@wikia/core';
 import { expect } from 'chai';
 import { SinonFakeTimers } from 'sinon';

--- a/spec/core/utils/try-property.spec.ts
+++ b/spec/core/utils/try-property.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { tryProperty, whichProperty } from '@wikia/core/utils';
 import { expect } from 'chai';
 

--- a/spec/core/utils/url-builder.spec.ts
+++ b/spec/core/utils/url-builder.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TargetingObject, TargetingService, targetingService } from '@wikia/core';
 import { AdSlot } from '@wikia/core/models/ad-slot';
 import { context } from '@wikia/core/services/context-service';

--- a/spec/core/video/vast-parser.spec.ts
+++ b/spec/core/video/vast-parser.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TargetingObject, TargetingService, targetingService } from '@wikia/core';
 import { context } from '@wikia/core/services/context-service';
 import { vastParser } from '@wikia/core/video/vast-parser';

--- a/spec/platforms/news-and-ratings/gamespot/setup/context/slots/gamefaqs-slots-definition-repository.spec.ts
+++ b/spec/platforms/news-and-ratings/gamespot/setup/context/slots/gamefaqs-slots-definition-repository.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context } from '@wikia/core';
 import { GameFAQsSlotsDefinitionRepository } from '@wikia/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-slots-definition-repository';
 import { expect } from 'chai';

--- a/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { GamespotTargetingSetup } from '@wikia/platforms/news-and-ratings/gamespot/setup/context/targeting/gamespot-targeting.setup';
 import { expect } from 'chai';
 

--- a/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { MetacriticTargetingSetup } from '@wikia/platforms/news-and-ratings/metacritic/setup/context/targeting/metacritic-targeting.setup';
 import { expect } from 'chai';
 

--- a/spec/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-anyclip.setup.spec.ts
+++ b/spec/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-anyclip.setup.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { expect } from 'chai';
 
 import { context, InstantConfigService, targetingService } from '@wikia/core';

--- a/spec/platforms/shared/bidders/bidders-state.setup.spec.ts
+++ b/spec/platforms/shared/bidders/bidders-state.setup.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/spec/platforms/shared/context/targeting/targeting-strategies/providers/common-tags.spec.ts
+++ b/spec/platforms/shared/context/targeting/targeting-strategies/providers/common-tags.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context } from '@wikia/core';
 import {
 	FandomContext,

--- a/spec/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.spec.ts
+++ b/spec/platforms/shared/context/targeting/targeting-strategies/providers/open-rtb2-tags.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '@wikia/core';
 import { OpenRtb2ContentCategories, OpenRtb2Object } from '@wikia/platforms/shared';
 import {

--- a/spec/platforms/shared/context/targeting/targeting-strategies/providers/page-level-taxonomy-tags.spec.ts
+++ b/spec/platforms/shared/context/targeting/targeting-strategies/providers/page-level-taxonomy-tags.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	FandomContext,
 	Page,

--- a/spec/platforms/shared/context/targeting/targeting-strategies/providers/site-level-taxonomy-tags.spec.ts
+++ b/spec/platforms/shared/context/targeting/targeting-strategies/providers/site-level-taxonomy-tags.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	FandomContext,
 	Page,

--- a/spec/platforms/shared/sequential-messaging/test_doubles/instant-config-service.spy.ts
+++ b/spec/platforms/shared/sequential-messaging/test_doubles/instant-config-service.spy.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { InstantConfigServiceInterface } from '@wikia/core';
 import { InstantConfigValue } from '@wikia/instant-config-loader';
 import { createStubInstance, SinonStubbedInstance } from 'sinon';

--- a/spec/platforms/shared/sequential-messaging/test_doubles/state-store.spy.ts
+++ b/spec/platforms/shared/sequential-messaging/test_doubles/state-store.spy.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { UserSequentialMessageState } from '@wikia/platforms/shared/sequential-messaging/domain/data-structures/user-sequential-message-state';
 import { UserSequentialMessageStateStoreInterface } from '@wikia/platforms/shared/sequential-messaging/domain/interfaces/user-sequential-message-state-store.interface';
 import { createStubInstance, SinonStubbedInstance } from 'sinon';

--- a/spec/platforms/shared/sequential-messaging/test_doubles/targetingService.spy.ts
+++ b/spec/platforms/shared/sequential-messaging/test_doubles/targetingService.spy.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { ChangeCallback, TargetingObject, TargetingServiceInterface } from '@wikia/core';
 import { createStubInstance, SinonStubbedInstance } from 'sinon';
 

--- a/spec/platforms/shared/services/no-ads-detector.spec.ts
+++ b/spec/platforms/shared/services/no-ads-detector.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { NoAdsDetector } from '@wikia/platforms/shared';
 import { expect } from 'chai';
 

--- a/spec/platforms/shared/setup/jwp-strategy-rules.setup.spec.ts
+++ b/spec/platforms/shared/setup/jwp-strategy-rules.setup.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, InstantConfigService } from '@wikia/core';
 import { JwpStrategyRulesSetup } from '@wikia/platforms/shared';
 import { expect } from 'chai';

--- a/spec/platforms/shared/setup/player.setup.spec.ts
+++ b/spec/platforms/shared/setup/player.setup.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	JWPlayerManager,
 	VastResponseData,

--- a/spec/platforms/shared/setup/tracking-parameters.setup.spec.ts
+++ b/spec/platforms/shared/setup/tracking-parameters.setup.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context } from '@wikia/core';
 import { WaitFor } from '@wikia/core/utils';
 import { TrackingParametersSetup } from '@wikia/platforms/shared';

--- a/spec/platforms/shared/tracking/data-warehouse-utils/dw-aggregated-data-gzip-compressor.spec.ts
+++ b/spec/platforms/shared/tracking/data-warehouse-utils/dw-aggregated-data-gzip-compressor.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import '@stardazed/streams-polyfill'; // provides types missing in currently used version of node
 import { DwAggregatedDataGzipCompressor } from '@wikia/platforms/shared/tracking/data-warehouse-utils/dw-aggregated-data-gzip-compressor';
 import { expect } from 'chai';

--- a/spec/platforms/shared/tracking/data-warehouse-utils/dw-traffic-aggregator.spec.ts
+++ b/spec/platforms/shared/tracking/data-warehouse-utils/dw-traffic-aggregator.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DataWarehouseParams } from '@wikia/platforms/shared';
 import { TrackingUrl } from '@wikia/platforms/shared/setup/tracking-urls';
 import { DwTrafficAggregator } from '@wikia/platforms/shared/tracking/data-warehouse-utils/dw-traffic-aggregator';

--- a/spec/platforms/shared/utils/instant-config.setup.spec.ts
+++ b/spec/platforms/shared/utils/instant-config.setup.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { InstantConfigService } from '@wikia/core';
 import { Binding, Container } from '@wikia/dependency-injection';
 import { InstantConfigSetup } from '@wikia/platforms/shared';

--- a/spec/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-dynamic-slots.setup.spec.ts
+++ b/spec/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-dynamic-slots.setup.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Anyclip, Connatix } from '@wikia/ad-services';
 import { communicationService, eventsRepository } from '@wikia/communication';
 import { AdSlot, AdSlotStatus, context, DomListener, InstantConfigService } from '@wikia/core';

--- a/src/ad-bidders/a9/index.ts
+++ b/src/ad-bidders/a9/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	CcpaSignalPayload,
 	communicationService,

--- a/src/ad-bidders/bidder-provider.ts
+++ b/src/ad-bidders/bidder-provider.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DEFAULT_MAX_DELAY, Dictionary, utils } from '@ad-engine/core';
 
 export interface BidderConfig {

--- a/src/ad-bidders/prebid/adapters/appnexus.ts
+++ b/src/ad-bidders/prebid/adapters/appnexus.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, Dictionary, targetingService } from '@ad-engine/core';
 import { PrebidNativeConfig } from '../native';
 import { PrebidAdapter } from '../prebid-adapter';

--- a/src/ad-bidders/prebid/adapters/gumgum.ts
+++ b/src/ad-bidders/prebid/adapters/gumgum.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PrebidAdapter } from '../prebid-adapter';
 import { PrebidAdSlotConfig } from '../prebid-models';
 

--- a/src/ad-bidders/prebid/adapters/kargo.ts
+++ b/src/ad-bidders/prebid/adapters/kargo.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PrebidAdapter } from '../prebid-adapter';
 import { PrebidAdSlotConfig } from '../prebid-models';
 

--- a/src/ad-bidders/prebid/adapters/magniteS2s.ts
+++ b/src/ad-bidders/prebid/adapters/magniteS2s.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PrebidAdapter } from '../prebid-adapter';
 import {
 	PrebidAdSlotConfig,

--- a/src/ad-bidders/prebid/adapters/nobid.ts
+++ b/src/ad-bidders/prebid/adapters/nobid.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PrebidAdapter } from '../prebid-adapter';
 import { PrebidAdSlotConfig } from '../prebid-models';
 

--- a/src/ad-bidders/prebid/adapters/ogury.ts
+++ b/src/ad-bidders/prebid/adapters/ogury.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PrebidAdapter } from '../prebid-adapter';
 import { PrebidAdSlotConfig } from '../prebid-models';
 

--- a/src/ad-bidders/prebid/adapters/ozone.ts
+++ b/src/ad-bidders/prebid/adapters/ozone.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository, UapLoadStatus } from '@ad-engine/communication';
 import { context, Dictionary, targetingService } from '@ad-engine/core';
 import { PrebidAdapter } from '../prebid-adapter';

--- a/src/ad-bidders/prebid/adapters/rubicon-display.ts
+++ b/src/ad-bidders/prebid/adapters/rubicon-display.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, Dictionary, targetingService } from '@ad-engine/core';
 import { PrebidAdapter } from '../prebid-adapter';
 import { PrebidAdSlotConfig } from '../prebid-models';

--- a/src/ad-bidders/prebid/adapters/rubicon.ts
+++ b/src/ad-bidders/prebid/adapters/rubicon.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, Dictionary, targetingService } from '@ad-engine/core';
 import { PrebidAdapter } from '../prebid-adapter';
 import {

--- a/src/ad-bidders/prebid/adapters/seedtag.ts
+++ b/src/ad-bidders/prebid/adapters/seedtag.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context } from '@ad-engine/core';
 import { PrebidAdapter } from '../prebid-adapter';
 import {

--- a/src/ad-bidders/prebid/adapters/triplelift.ts
+++ b/src/ad-bidders/prebid/adapters/triplelift.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PrebidAdapter } from '../prebid-adapter';
 import { PrebidAdSlotConfig } from '../prebid-models';
 

--- a/src/ad-bidders/prebid/adapters/webads.ts
+++ b/src/ad-bidders/prebid/adapters/webads.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PrebidAdapter } from '../prebid-adapter';
 import { PrebidAdSlotConfig } from '../prebid-models';
 

--- a/src/ad-bidders/prebid/adapters/wikia.ts
+++ b/src/ad-bidders/prebid/adapters/wikia.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, Dictionary, pbjsFactory, utils } from '@ad-engine/core';
 import { PrebidNativeConfig } from '../native';
 import { PrebidAdapter } from '../prebid-adapter';

--- a/src/ad-bidders/prebid/id5/id5.ts
+++ b/src/ad-bidders/prebid/id5/id5.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, targetingService, utils } from '@ad-engine/core';
 import { UserIdConfig } from '../index';
 

--- a/src/ad-bidders/prebid/index.ts
+++ b/src/ad-bidders/prebid/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	communicationService,
 	eventsRepository,

--- a/src/ad-bidders/prebid/intent-iq/intent-iq.ts
+++ b/src/ad-bidders/prebid/intent-iq/intent-iq.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import {
 	context,

--- a/src/ad-bidders/prebid/liveintent-connected-id/connected-id.ts
+++ b/src/ad-bidders/prebid/liveintent-connected-id/connected-id.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, utils } from '@ad-engine/core';
 import { UserIdConfig } from '../index';
 

--- a/src/ad-bidders/prebid/liveramp-id/index.ts
+++ b/src/ad-bidders/prebid/liveramp-id/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, utils } from '@ad-engine/core';
 import { UserIdConfig } from '../index';
 

--- a/src/ad-bidders/prebid/native/prebid-native-helper.ts
+++ b/src/ad-bidders/prebid/native/prebid-native-helper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export class PrebidNativeHelper {
 	static triggerPixel(url: string, done: () => any, timeout: number): void {
 		const img = new Image();

--- a/src/ad-bidders/prebid/native/prebid-native-provider.ts
+++ b/src/ad-bidders/prebid/native/prebid-native-provider.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { AdSlotStatus, BaseServiceSetup, slotService, utils } from '@ad-engine/core';
 import { PrebidNativeData } from './native-models';

--- a/src/ad-bidders/prebid/prebid-helper.ts
+++ b/src/ad-bidders/prebid/prebid-helper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, Dictionary, pbjsFactory, slotService } from '@ad-engine/core';
 import { isUsedAsAlias } from '../bidder-helper';
 import { PrebidAdapterConfig } from './prebid-models';

--- a/src/ad-bidders/prebid/price-helper.ts
+++ b/src/ad-bidders/prebid/price-helper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '@ad-engine/core';
 import { adaptersRegistry } from './adapters-registry';
 import { getWinningBid } from './prebid-helper';

--- a/src/ad-bidders/prebid/utils/id-retriever.ts
+++ b/src/ad-bidders/prebid/utils/id-retriever.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { context, pbjsFactory, targetingService, UniversalStorage, utils } from '@ad-engine/core';
 

--- a/src/ad-bidders/prebid/yahoo-connect-id/yahoo-connect-id.ts
+++ b/src/ad-bidders/prebid/yahoo-connect-id/yahoo-connect-id.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, targetingService, utils } from '@ad-engine/core';
 
 interface YahooConnectIdConfig {

--- a/src/ad-bidders/wrappers/apstag.ts
+++ b/src/ad-bidders/wrappers/apstag.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	CcpaSignalPayload,
 	communicationService,

--- a/src/ad-products/common/product-info.ts
+++ b/src/ad-products/common/product-info.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, Dictionary, utils } from '@ad-engine/core';
 import { FAN_TAKEOVER_TYPES } from '../templates/uap/constants';
 

--- a/src/ad-products/templates/interface/close-button.ts
+++ b/src/ad-products/templates/interface/close-button.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Button } from './button';
 import { createIcon, icons } from './icons';
 import { UiComponent } from './ui-component';

--- a/src/ad-products/templates/interface/video/learn-more.ts
+++ b/src/ad-products/templates/interface/video/learn-more.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { utils } from '@ad-engine/core';
 import { createIcon, icons } from '../icons';

--- a/src/ad-products/templates/interface/video/panel.ts
+++ b/src/ad-products/templates/interface/video/panel.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export class Panel {
 	private panelContainer: HTMLDivElement;
 

--- a/src/ad-products/templates/interface/video/pause-control.ts
+++ b/src/ad-products/templates/interface/video/pause-control.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createIcon, icons } from '../icons';
 
 export class PauseControl {

--- a/src/ad-products/templates/interface/video/player-overlay.ts
+++ b/src/ad-products/templates/interface/video/player-overlay.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { createIcon, icons } from '../icons';
 import { onVideoOverlayClick } from '../listeners/player-overlay-click-listener';

--- a/src/ad-products/templates/interface/video/progress-bar.ts
+++ b/src/ad-products/templates/interface/video/progress-bar.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { slotTweaker } from '@ad-engine/core';
 import { PorvataPlayer } from '../../../video/porvata/porvata-player';
 

--- a/src/ad-products/templates/interface/video/toggle-fullscreen.ts
+++ b/src/ad-products/templates/interface/video/toggle-fullscreen.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createIcon, icons } from '../icons';
 
 export class ToggleFullscreen {

--- a/src/ad-products/templates/interface/video/toggle-ui.ts
+++ b/src/ad-products/templates/interface/video/toggle-ui.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { utils } from '@ad-engine/core';
 

--- a/src/ad-products/templates/interface/video/volume-control.ts
+++ b/src/ad-products/templates/interface/video/volume-control.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createIcon, icons } from '../icons';
 
 function createVolumeControl(): HTMLDivElement {

--- a/src/ad-products/templates/uap/universal-ad-package.ts
+++ b/src/ad-products/templates/uap/universal-ad-package.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlotEventPayload,
 	communicationService,

--- a/src/ad-products/video/jwplayer/handlers/jwplayer-handler.ts
+++ b/src/ad-products/video/jwplayer/handlers/jwplayer-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { utils } from '@ad-engine/core';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge, Observable } from 'rxjs';

--- a/src/ad-products/video/jwplayer/handlers/jwplayer-tracking-handler.ts
+++ b/src/ad-products/video/jwplayer/handlers/jwplayer-tracking-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, VideoData, VideoEventData, VideoEventProvider } from '@ad-engine/core';
 import { Injectable } from '@wikia/dependency-injection';
 import Cookies from 'js-cookie';

--- a/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
+++ b/src/ad-products/video/jwplayer/helpers/jwplayer-helper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	AdSlotEvent,

--- a/src/ad-products/video/jwplayer/helpers/video-display-takeover-synchronizer.ts
+++ b/src/ad-products/video/jwplayer/helpers/video-display-takeover-synchronizer.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { displayAndVideoAdsSyncContext, utils } from '@ad-engine/core';
 import { universalAdPackage } from '../../../templates';
 

--- a/src/ad-products/video/jwplayer/streams/jwplayer-stream-state.ts
+++ b/src/ad-products/video/jwplayer/streams/jwplayer-stream-state.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { RxJsOperator, VastParams, vastParser } from '@ad-engine/core';
 import { combineLatest, merge, Observable } from 'rxjs';
 import { map, scan, shareReplay, startWith, withLatestFrom } from 'rxjs/operators';

--- a/src/ad-products/video/porvata/google-ima-wrapper.ts
+++ b/src/ad-products/video/porvata/google-ima-wrapper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService } from '@ad-engine/communication';
 import { AdSlot, AdSlotEvent, context, utils } from '@ad-engine/core';
 import { PorvataSettings } from './porvata-settings';

--- a/src/ad-products/video/porvata/native-fullscreen.ts
+++ b/src/ad-products/video/porvata/native-fullscreen.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { utils } from '@ad-engine/core';
 
 export class NativeFullscreen {

--- a/src/ad-products/video/porvata/plugins/ias/ias-video-tracker.ts
+++ b/src/ad-products/video/porvata/plugins/ias/ias-video-tracker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { context, slotService, utils } from '@ad-engine/core';
 import { PorvataPlayer } from '../../porvata-player';

--- a/src/ad-products/video/porvata/porvata-dom.ts
+++ b/src/ad-products/video/porvata/porvata-dom.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, vastDebugger } from '@ad-engine/core';
 
 export class PorvataDom {

--- a/src/ad-products/video/porvata/porvata-factory.ts
+++ b/src/ad-products/video/porvata/porvata-factory.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { AdSlot, AdSlotStatus, slotService, utils } from '@ad-engine/core';
 import { GoogleImaWrapper } from './google-ima-wrapper';

--- a/src/ad-products/video/porvata/porvata-listener.ts
+++ b/src/ad-products/video/porvata/porvata-listener.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlotEvent,
 	context,

--- a/src/ad-products/video/porvata/porvata-player.ts
+++ b/src/ad-products/video/porvata/porvata-player.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, AdSlotStatus, Dictionary, utils } from '@ad-engine/core';
 import { GoogleImaWrapper } from './google-ima-wrapper';
 import { NativeFullscreen } from './native-fullscreen';

--- a/src/ad-products/video/porvata/porvata-settings.ts
+++ b/src/ad-products/video/porvata/porvata-settings.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, Dictionary, SlotTargeting } from '@ad-engine/core';
 
 enum VpaidMode {

--- a/src/ad-products/video/porvata/porvata.ts
+++ b/src/ad-products/video/porvata/porvata.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlotEvent, slotService, SlotTargeting, utils } from '@ad-engine/core';
 import { PorvataFactory } from './porvata-factory';
 import { PorvataListener } from './porvata-listener';

--- a/src/ad-services/anyclip/index.ts
+++ b/src/ad-services/anyclip/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository, UapLoadStatus } from '@ad-engine/communication';
 import {
 	AdSlot,

--- a/src/ad-services/ats/index.ts
+++ b/src/ad-services/ats/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { BaseServiceSetup, context, tcf, usp, utils } from '@ad-engine/core';
 

--- a/src/ad-services/audigent/index.ts
+++ b/src/ad-services/audigent/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import {
 	BaseServiceSetup,

--- a/src/ad-services/bt-force/index.ts
+++ b/src/ad-services/bt-force/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, utils } from '@ad-engine/core';
 import { trackBab } from '../../platforms/shared';
 

--- a/src/ad-services/bt-rec/index.ts
+++ b/src/ad-services/bt-rec/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, utils } from '@ad-engine/core';
 import { trackBab } from '../../platforms/shared';
 

--- a/src/ad-services/connatix/connatix-tracker.ts
+++ b/src/ad-services/connatix/connatix-tracker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { utils, VideoData, VideoEventProvider, VideoTracker } from '@ad-engine/core';
 import { ConnatixPlayerApi, ConnatixPlayerType } from './connatix-player';
 

--- a/src/ad-services/connatix/player-injector.ts
+++ b/src/ad-services/connatix/player-injector.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, context, utils } from '@ad-engine/core';
 import { ConnatixPlayerApi, ConnatixPlayerInterface } from './connatix-player';
 import { logGroup } from './index';

--- a/src/ad-services/double-verify/index.ts
+++ b/src/ad-services/double-verify/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { BaseServiceSetup, context, SlotConfig, targetingService, utils } from '@ad-engine/core';
 
 const logGroup = 'double-verify';

--- a/src/ad-services/duration-media/index.ts
+++ b/src/ad-services/duration-media/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { BaseServiceSetup, context, utils } from '@ad-engine/core';
 
 const logGroup = 'duration-media';

--- a/src/ad-services/ias-publisher-optimization/index.ts
+++ b/src/ad-services/ias-publisher-optimization/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	BaseServiceSetup,
 	context,

--- a/src/ad-services/live-connect/index.ts
+++ b/src/ad-services/live-connect/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { BaseServiceSetup, localCache, UniversalStorage, utils } from '@ad-engine/core';
 

--- a/src/ad-services/nielsen/index.ts
+++ b/src/ad-services/nielsen/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	BaseServiceSetup,
 	context,

--- a/src/ad-services/open-web/index.ts
+++ b/src/ad-services/open-web/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository, UapLoadStatus } from '@ad-engine/communication';
 import {
 	BaseServiceSetup,

--- a/src/ad-services/open-web/utils/placements-handler.ts
+++ b/src/ad-services/open-web/utils/placements-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context } from '@ad-engine/core';
 import { Injectable } from '@wikia/dependency-injection';
 import { PlacementsBuilder } from './placements-builder';

--- a/src/ad-services/system1/index.ts
+++ b/src/ad-services/system1/index.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import {
 	BaseServiceSetup,

--- a/src/ad-tracking/base-tracker.ts
+++ b/src/ad-tracking/base-tracker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TrackingBidDefinition } from '@ad-engine/communication';
 import { AdSlot, Dictionary } from '@ad-engine/core';
 

--- a/src/ad-tracking/click-tracker.ts
+++ b/src/ad-tracking/click-tracker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, EventOptions, eventsRepository } from '@ad-engine/communication';
 import { AdSlot, AdSlotEvent, AdSlotStatus, Dictionary, slotService, utils } from '@ad-engine/core';
 import { BaseTracker, BaseTrackerInterface } from './base-tracker';

--- a/src/ad-tracking/compilers/bidder-tracking-compiler.ts
+++ b/src/ad-tracking/compilers/bidder-tracking-compiler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { slotService } from '@ad-engine/core';
 import { CompilerPartial } from '../base-tracker';
 

--- a/src/ad-tracking/compilers/slot-bidders-tracking-compiler.ts
+++ b/src/ad-tracking/compilers/slot-bidders-tracking-compiler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary, SlotPriceProvider } from '@ad-engine/core';
 import { CompilerPartial } from '../base-tracker';
 

--- a/src/ad-tracking/compilers/slot-properties-tracking-compiler.ts
+++ b/src/ad-tracking/compilers/slot-properties-tracking-compiler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { CompilerPartial } from '../base-tracker';
 
 export const slotPropertiesTrackingCompiler = ({

--- a/src/ad-tracking/compilers/slot-tracking-compiler.ts
+++ b/src/ad-tracking/compilers/slot-tracking-compiler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	context,
 	InstantConfigCacheStorage,

--- a/src/ad-tracking/compilers/viewability-properties-tracking-compiler.ts
+++ b/src/ad-tracking/compilers/viewability-properties-tracking-compiler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { CompilerPartial } from '../base-tracker';
 
 export const viewabilityPropertiesTrackingCompiler = ({

--- a/src/ad-tracking/cta-tracker.ts
+++ b/src/ad-tracking/cta-tracker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { slotService } from '@ad-engine/core';
 import { BaseTracker, BaseTrackerInterface } from './base-tracker';

--- a/src/ad-tracking/postmessage-tracker.ts
+++ b/src/ad-tracking/postmessage-tracker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary, FuncPipeline, FuncPipelineStep, messageBus } from '@ad-engine/core';
 
 export const TrackingTarget = {

--- a/src/ad-tracking/slot-tracker.ts
+++ b/src/ad-tracking/slot-tracker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService } from '@ad-engine/communication';
 import { AdSlotEvent, AdSlotStatus } from '@ad-engine/core';
 import { BaseTracker, BaseTrackerInterface } from './base-tracker';

--- a/src/communication/communication-service.ts
+++ b/src/communication/communication-service.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Action, Communicator, setupPostQuecast } from '@wikia/post-quecast';
 import { fromEventPattern, merge, Observable, Subject } from 'rxjs';
 import { filter, shareReplay, skip, take } from 'rxjs/operators';

--- a/src/communication/only-new.ts
+++ b/src/communication/only-new.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { RxJsOperator } from '@ad-engine/core';
 import { Action } from '@wikia/post-quecast';
 import { Observable } from 'rxjs';

--- a/src/core/ad-engine.ts
+++ b/src/core/ad-engine.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { scrollListener } from './listeners';
 import { AdSlot } from './models';

--- a/src/core/listeners/dom-listener.ts
+++ b/src/core/listeners/dom-listener.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Injectable } from '@wikia/dependency-injection';
 import { animationFrameScheduler, fromEvent, Observable } from 'rxjs';
 import { observeOn, publish, refCount } from 'rxjs/operators';

--- a/src/core/listeners/scroll-listener.ts
+++ b/src/core/listeners/scroll-listener.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '../';
 import { slotService } from '../services';
 import { getTopOffset, getViewportHeight, logger } from '../utils';

--- a/src/core/log-version.ts
+++ b/src/core/log-version.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { logger } from './utils';
 
 export function logVersion(): void {

--- a/src/core/models/ad-slot.ts
+++ b/src/core/models/ad-slot.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import type { AdStackPayload } from '../';
 import {

--- a/src/core/pipeline/imps/partner-pipeline/base-service-setup.ts
+++ b/src/core/pipeline/imps/partner-pipeline/base-service-setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Injectable } from '@wikia/dependency-injection';
 import { context, InstantConfigService } from '../../../services';
 import { isCoppaSubject, logger, WaitFor } from '../../../utils';

--- a/src/core/pipeline/imps/process-pipeline/process-pipeline.ts
+++ b/src/core/pipeline/imps/process-pipeline/process-pipeline.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Container, Injectable } from '@wikia/dependency-injection';
 import { Type } from '../../../models/dictionary';
 import { Pipeline } from '../../pipeline';

--- a/src/core/providers/gpt-provider.ts
+++ b/src/core/providers/gpt-provider.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { getAdStack } from '../ad-engine';
 import { AdSlotEvent, AdSlotStatus, Dictionary, type AdSlot } from '../models';

--- a/src/core/providers/nativo/lazy-loader.ts
+++ b/src/core/providers/nativo/lazy-loader.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Observable } from 'rxjs';
 import { filter, take, tap } from 'rxjs/operators';
 

--- a/src/core/providers/nativo/nativo-provider.ts
+++ b/src/core/providers/nativo/nativo-provider.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot } from '../../models';
 import { logger } from '../../utils';
 import { Provider } from '../provider';

--- a/src/core/providers/nativo/nativo.ts
+++ b/src/core/providers/nativo/nativo.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository, UapLoadStatus } from '@ad-engine/communication';
 
 import { AdSlotStatus } from '../../models';

--- a/src/core/providers/prebidium-provider.ts
+++ b/src/core/providers/prebidium-provider.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	BiddersEventPayload,
 	communicationService,

--- a/src/core/services/bab-detection.ts
+++ b/src/core/services/bab-detection.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 // blockadblock doesn't export anything meaningful
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 // it sets blockAdBlock and BlockAdBlock properties on window

--- a/src/core/services/btf-blocker-service.ts
+++ b/src/core/services/btf-blocker-service.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { AdSlot, AdSlotStatus, Dictionary, SlotConfig } from '../models';
 import { AdSlotEvent } from '../models/ad-slot-event';

--- a/src/core/services/context-service.ts
+++ b/src/core/services/context-service.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '../models';
 import { debug } from './debug';
 

--- a/src/core/services/cookie-storage-adapter.ts
+++ b/src/core/services/cookie-storage-adapter.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Cookies from 'js-cookie';
 import { StorageProvider } from './universal-storage';
 

--- a/src/core/services/custom-ad-loader.ts
+++ b/src/core/services/custom-ad-loader.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, Dictionary } from '../models';
 import { slotService } from './slot-service';
 import { templateService } from './template-service';

--- a/src/core/services/debug.ts
+++ b/src/core/services/debug.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { queryString } from '../utils/query-string';
 import { CookieStorageAdapter } from './cookie-storage-adapter';
 

--- a/src/core/services/global-context-service.ts
+++ b/src/core/services/global-context-service.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { utils } from '../index';
 
 export enum GlobalContextCategories {

--- a/src/core/services/instant-config-cache-storage-serializer.ts
+++ b/src/core/services/instant-config-cache-storage-serializer.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { CacheDictionary } from './instant-config-cache-storage';
 
 const KEY_SEPARATOR = '|';

--- a/src/core/services/instant-config/instant-config.service.ts
+++ b/src/core/services/instant-config/instant-config.service.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import {
 	BrowserMatcher,

--- a/src/core/services/local-cache.ts
+++ b/src/core/services/local-cache.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '../models';
 import { Storage, UniversalStorage } from './universal-storage';
 

--- a/src/core/services/pbjs-factory.ts
+++ b/src/core/services/pbjs-factory.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { logger, scriptLoader } from '../utils';
 import { context } from './context-service';
 

--- a/src/core/services/slot-creator.ts
+++ b/src/core/services/slot-creator.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService } from '@ad-engine/communication';
 import { Injectable } from '@wikia/dependency-injection';
 import { AdSlotEvent, RepeatConfig } from '../models';

--- a/src/core/services/slot-placeholder-injector.ts
+++ b/src/core/services/slot-placeholder-injector.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AD_LABEL_CLASS,
 	getTopOffset,

--- a/src/core/services/slot-refresher.ts
+++ b/src/core/services/slot-refresher.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository, UapLoadStatus } from '@ad-engine/communication';
 import { AdSlot, AdSlotEvent } from '../models';
 import { GptProvider } from '../providers';

--- a/src/core/services/slot-repeater.ts
+++ b/src/core/services/slot-repeater.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, RepeatConfig, SlotConfig } from '../models';
 import { generateUniqueId, logger, stringBuilder } from '../utils';
 import { context } from './context-service';

--- a/src/core/services/slot-service.ts
+++ b/src/core/services/slot-service.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { AdSlotEvent, getAdStack, targetingService, utils } from '../';
 import { AdSlot, Dictionary, SlotConfig } from '../models';

--- a/src/core/services/slot-tweaker.ts
+++ b/src/core/services/slot-tweaker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot } from '../models';
 import { isIframe, logger } from '../utils';
 import { messageBus } from './message-bus';

--- a/src/core/services/targeting-service.ts
+++ b/src/core/services/targeting-service.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { debug } from './debug';
 
 export type ChangeCallback = (key: string | null, value: any) => void;

--- a/src/core/services/template-service.ts
+++ b/src/core/services/template-service.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	communicationService,
 	eventsRepository,

--- a/src/core/services/templates-registry/template-machine.ts
+++ b/src/core/services/templates-registry/template-machine.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Subject } from 'rxjs';
 import { Dictionary } from '../../models';
 import { TemplateAction } from './template-action';

--- a/src/core/services/templates-registry/template-registry.ts
+++ b/src/core/services/templates-registry/template-registry.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { Container, Injectable } from '@wikia/dependency-injection';
 import { Observable, Subject } from 'rxjs';

--- a/src/core/services/templates-registry/template-state.ts
+++ b/src/core/services/templates-registry/template-state.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createExtendedPromise } from '../../utils';
 import { TemplateStateHandler } from './template-state-handler';
 import { TemplateTransition } from './template-state-transition';

--- a/src/core/services/universal-storage.ts
+++ b/src/core/services/universal-storage.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '../models';
 import { logger } from '../utils';
 

--- a/src/core/utils/client.ts
+++ b/src/core/utils/client.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 // blockadblock doesn't export anything meaningful
 // it sets blockAdBlock and BlockAdBlock properties on window
 import 'blockadblock';

--- a/src/core/utils/debounce.ts
+++ b/src/core/utils/debounce.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export function withDebounce(
 	original: (...args: unknown[]) => void,
 	timeout: number,

--- a/src/core/utils/decorate.ts
+++ b/src/core/utils/decorate.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export function decorate(decorator: any): any {
 	return function (target: any, key: string | symbol, descriptor: PropertyDescriptor) {
 		const fn = descriptor.value;

--- a/src/core/utils/dimensions.ts
+++ b/src/core/utils/dimensions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot } from '..';
 
 export interface ElementOffset {

--- a/src/core/utils/flow-control.ts
+++ b/src/core/utils/flow-control.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export const wait = (milliseconds = 0) =>
 	new Promise((resolve, reject) => {
 		if (typeof milliseconds !== 'number') {

--- a/src/core/utils/geo.ts
+++ b/src/core/utils/geo.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { CacheData, context, InstantConfigCacheStorage } from '../services';
 
 const cacheMarker = '-cached';

--- a/src/core/utils/global-timeout.ts
+++ b/src/core/utils/global-timeout.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Injectable } from '@wikia/dependency-injection';
 import { logger } from './logger';
 

--- a/src/core/utils/i18n.ts
+++ b/src/core/utils/i18n.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context } from '../services/context-service';
 import { TRANSLATIONS } from './translations';
 

--- a/src/core/utils/iframe-builder.ts
+++ b/src/core/utils/iframe-builder.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export class IframeBuilder {
 	create(element: HTMLElement, htmlContent?: string): HTMLIFrameElement {
 		const iframe = this.createEmptyIframe();

--- a/src/core/utils/is-coppa-subject.ts
+++ b/src/core/utils/is-coppa-subject.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { GlobalContextCategories, globalContextService } from '../index';
 
 export function isCoppaSubject(): boolean {

--- a/src/core/utils/lazy-queue.ts
+++ b/src/core/utils/lazy-queue.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /**
  * @deprecated
  * Please use LazyQueue class instead

--- a/src/core/utils/script-loader.ts
+++ b/src/core/utils/script-loader.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export interface ScriptLoaderInterface {
 	loadScript(src: string): Promise<Event>;
 }

--- a/src/core/utils/string-builder.ts
+++ b/src/core/utils/string-builder.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, targetingService } from '../services';
 
 class StringBuilder {

--- a/src/core/utils/targeting.ts
+++ b/src/core/utils/targeting.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '../models';
 import { CookieStorageAdapter, targetingService } from '../services/';
 import { context } from '../services/context-service';

--- a/src/core/utils/timed-partner-script-loader.ts
+++ b/src/core/utils/timed-partner-script-loader.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository } from '@ad-engine/communication';
 import { logger } from './logger';
 import { ScriptLoader } from './script-loader';

--- a/src/core/utils/try-property.ts
+++ b/src/core/utils/try-property.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '../models';
 
 export function whichProperty(obj: Dictionary = {}, properties: string[] = []): string | undefined {

--- a/src/core/utils/viewport-observer.ts
+++ b/src/core/utils/viewport-observer.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { scrollListener } from '../listeners';
 import { isInViewport } from './dimensions';
 

--- a/src/core/utils/wait-for.ts
+++ b/src/core/utils/wait-for.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 type Condition = () => boolean;
 
 export class WaitFor {

--- a/src/core/video/vast-parser.ts
+++ b/src/core/video/vast-parser.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '../models';
 import { ADX } from '../providers';
 import { queryString } from '../utils';

--- a/src/core/wrappers/global-variable-setter.ts
+++ b/src/core/wrappers/global-variable-setter.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export class RuntimeVariableSetter {
 	addVariable(name, value): void {
 		window.ads.runtime = window.ads.runtime || ({} as Runtime);

--- a/src/core/wrappers/usp.ts
+++ b/src/core/wrappers/usp.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export class Usp {
 	get exists(): boolean {
 		return !!window.__uspapi;

--- a/src/newfile.ts
+++ b/src/newfile.ts
@@ -1,5 +1,0 @@
-// @ts-strict-ignore
-const element = document.getElementById('ID');
-
-// this line should not cause `TS18047: element is possibly null` error as strict mode is disabled
-console.log(element.classList);

--- a/src/newfile.ts
+++ b/src/newfile.ts
@@ -1,4 +1,5 @@
+// @ts-strict-ignore
 const element = document.getElementById('ID');
 
-// this line should cause `TS18047: element is possibly null` error in strict mode
+// this line should not cause `TS18047: element is possibly null` error as strict mode is disabled
 console.log(element.classList);

--- a/src/newfile.ts
+++ b/src/newfile.ts
@@ -1,0 +1,4 @@
+const element = document.getElementById('ID');
+
+// this line should cause `TS18047: element is possibly null` error in strict mode
+console.log(element.classList);

--- a/src/platforms/bingebot/templates/bingebot-templates.setup.ts
+++ b/src/platforms/bingebot/templates/bingebot-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/bingebot/templates/handlers/sponsored-logo/sponsored-logo-handler.ts
+++ b/src/platforms/bingebot/templates/handlers/sponsored-logo/sponsored-logo-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, TEMPLATE, TemplateStateHandler } from '@wikia/ad-engine';
 import { Inject, Injectable } from '@wikia/dependency-injection';
 import { sponsoredLogoComponent } from './sponsored-logo-component';

--- a/src/platforms/bingebot/templates/handlers/sponsored-text-logo/sponsored-text-logo-handler.ts
+++ b/src/platforms/bingebot/templates/handlers/sponsored-text-logo/sponsored-text-logo-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, TEMPLATE, TemplateStateHandler } from '@wikia/ad-engine';
 import { Inject, Injectable } from '@wikia/dependency-injection';
 import { sponsoredTextLogoComponent } from './sponsored-text-logo-component';

--- a/src/platforms/f2/modes/f2-ads.mode.ts
+++ b/src/platforms/f2/modes/f2-ads.mode.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdEngineStackSetup, GptSetup, PlayerSetup, WadRunner } from '@platforms/shared';
 import {
 	Audigent,

--- a/src/platforms/f2/setup/context/targeting/f2-targeting.setup.ts
+++ b/src/platforms/f2/setup/context/targeting/f2-targeting.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	context,
 	DiProcess,

--- a/src/platforms/f2/setup/dynamic-slots/f2-slots-definition-repository.ts
+++ b/src/platforms/f2/setup/dynamic-slots/f2-slots-definition-repository.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { activateFloorAdhesionOnUAP, SlotSetupDefinition } from '@platforms/shared';
 import {
 	AdSlot,

--- a/src/platforms/f2/templates/bfaa-template.ts
+++ b/src/platforms/f2/templates/bfaa-template.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdvertisementLabelHandler,
 	BfaaBootstrapHandler,

--- a/src/platforms/f2/templates/f2-templates.setup.ts
+++ b/src/platforms/f2/templates/f2-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { StickedBoxadHelper } from '@platforms/shared';
 import {
 	context,

--- a/src/platforms/news-and-ratings/comicvine/templates/comicvine-templates.setup.ts
+++ b/src/platforms/news-and-ratings/comicvine/templates/comicvine-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-anyclip.setup.ts
+++ b/src/platforms/news-and-ratings/gamefaqs/setup/context/slots/gamefaqs-anyclip.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { insertSlots } from '@platforms/shared';
 import { context, DiProcess } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';

--- a/src/platforms/news-and-ratings/gamefaqs/templates/gamefaqs-templates.setup.ts
+++ b/src/platforms/news-and-ratings/gamefaqs/templates/gamefaqs-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/news-and-ratings/gamespot/setup/context/dynamic-slots/gamespot-dynamic-slots.setup.ts
+++ b/src/platforms/news-and-ratings/gamespot/setup/context/dynamic-slots/gamespot-dynamic-slots.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { insertSlots } from '@platforms/shared';
 import { context, DiProcess } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';

--- a/src/platforms/news-and-ratings/gamespot/setup/page-change-observers/gamespot-infinite-scroll-observer.setup.ts
+++ b/src/platforms/news-and-ratings/gamespot/setup/page-change-observers/gamespot-infinite-scroll-observer.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, DiProcess, targetingService, utils } from '@wikia/ad-engine';
 
 export class GamespotInfiniteScrollObserverSetup implements DiProcess {

--- a/src/platforms/news-and-ratings/gamespot/setup/page-change-observers/gamespot-seamless-content-observer.setup.ts
+++ b/src/platforms/news-and-ratings/gamespot/setup/page-change-observers/gamespot-seamless-content-observer.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, DiProcess, targetingService, utils } from '@wikia/ad-engine';
 
 export class GamespotSeamlessContentObserverSetup implements DiProcess {

--- a/src/platforms/news-and-ratings/gamespot/templates/gamespot-templates.setup.ts
+++ b/src/platforms/news-and-ratings/gamespot/templates/gamespot-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/news-and-ratings/giantbomb/templates/giantbomb-templates.setup.ts
+++ b/src/platforms/news-and-ratings/giantbomb/templates/giantbomb-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/news-and-ratings/metacritic-neutron/setup/page-change-observers/metacritic-neutron-see-more-button-click-listener.setup.ts
+++ b/src/platforms/news-and-ratings/metacritic-neutron/setup/page-change-observers/metacritic-neutron-see-more-button-click-listener.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, DiProcess, targetingService, utils } from '@wikia/ad-engine';
 
 export class MetacriticNeutronSeeMoreButtonClickListenerSetup implements DiProcess {

--- a/src/platforms/news-and-ratings/metacritic-neutron/templates/metacritic-neutron-templates.setup.ts
+++ b/src/platforms/news-and-ratings/metacritic-neutron/templates/metacritic-neutron-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/news-and-ratings/metacritic/templates/metacritic-templates.setup.ts
+++ b/src/platforms/news-and-ratings/metacritic/templates/metacritic-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/news-and-ratings/shared/setup/context/targeting/news-and-ratings-targeting.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/context/targeting/news-and-ratings-targeting.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	communicationService,
 	context,

--- a/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-anyclip.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-anyclip.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { insertSlots } from '@platforms/shared';
 import { context, DiProcess, targetingService, utils } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';

--- a/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-dynamic-slots-neutron.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-dynamic-slots-neutron.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { insertSlots, SlotSetupDefinition } from '@platforms/shared';
 import {
 	AdSlot,

--- a/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-dynamic-slots.setup.ts
+++ b/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-dynamic-slots.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { insertSlots } from '@platforms/shared';
 import {
 	btfBlockerService,

--- a/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-slots-definition-repository.ts
+++ b/src/platforms/news-and-ratings/shared/setup/dynamic-slots/news-and-ratings-slots-definition-repository.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { activateFloorAdhesionOnUAP, SlotSetupDefinition } from '@platforms/shared';
 import {
 	AdSlot,

--- a/src/platforms/news-and-ratings/shared/templates/bfaa-template.ts
+++ b/src/platforms/news-and-ratings/shared/templates/bfaa-template.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdvertisementLabelHandler,
 	BfaaBootstrapHandler,

--- a/src/platforms/news-and-ratings/tvguide-mtc/templates/tvguide-mtc-templates.setup.ts
+++ b/src/platforms/news-and-ratings/tvguide-mtc/templates/tvguide-mtc-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/news-and-ratings/tvguide/templates/tvguide-templates.setup.ts
+++ b/src/platforms/news-and-ratings/tvguide/templates/tvguide-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/shared/consent/consent-management-platform.setup.ts
+++ b/src/platforms/shared/consent/consent-management-platform.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	CcpaSignalPayload,
 	communicationService,

--- a/src/platforms/shared/context/targeting/targeting-strategies/factories/create-fandom-context.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/factories/create-fandom-context.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { FandomContext, Page, Site } from '../models/fandom-context';
 
 export function createFandomContext() {

--- a/src/platforms/shared/context/targeting/targeting-strategies/models/fandom-context.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/models/fandom-context.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export class FandomContext {
 	constructor(
 		public readonly site: Site,

--- a/src/platforms/shared/context/targeting/targeting-strategies/providers/common-tags.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/providers/common-tags.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, SlotTargeting, utils } from '@wikia/ad-engine';
 import { getDomain } from '../../../../utils/get-domain';
 import { getMediaWikiVariable } from '../../../../utils/get-media-wiki-variable';

--- a/src/platforms/shared/context/targeting/targeting-strategies/providers/site-level-taxonomy-tags.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/providers/site-level-taxonomy-tags.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TargetingProvider } from '../interfaces/targeting-provider';
 import { FandomContext } from '../models/fandom-context';
 

--- a/src/platforms/shared/context/targeting/targeting-strategies/structures/prefix-decorator.ts
+++ b/src/platforms/shared/context/targeting/targeting-strategies/structures/prefix-decorator.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TargetingProvider } from '../interfaces/targeting-provider';
 
 export class PrefixDecorator implements TargetingProvider<TaxonomyTags> {

--- a/src/platforms/shared/dynamic-slots/nativo-slots-definition-repository.ts
+++ b/src/platforms/shared/dynamic-slots/nativo-slots-definition-repository.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Injectable } from '@wikia/dependency-injection';
 
 import {

--- a/src/platforms/shared/dynamic-slots/sticked-boxad-helper.ts
+++ b/src/platforms/shared/dynamic-slots/sticked-boxad-helper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlotEvent,
 	AdSlotStatus,

--- a/src/platforms/shared/handlers/gallery-lightbox-handler.ts
+++ b/src/platforms/shared/handlers/gallery-lightbox-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlotStatus,
 	communicationService,

--- a/src/platforms/shared/modes/no-ads.mode.ts
+++ b/src/platforms/shared/modes/no-ads.mode.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	Apstag,
 	Ats,

--- a/src/platforms/shared/sequential-messaging/infrastructure/user-sequential-message-state-store.ts
+++ b/src/platforms/shared/sequential-messaging/infrastructure/user-sequential-message-state-store.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Cookies from 'js-cookie';
 import {
 	SequenceState,

--- a/src/platforms/shared/setup/base-context.setup.ts
+++ b/src/platforms/shared/setup/base-context.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	communicationService,
 	context,

--- a/src/platforms/shared/setup/gpt.setup.ts
+++ b/src/platforms/shared/setup/gpt.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { BaseServiceSetup, communicationService, eventsRepository, utils } from '@wikia/ad-engine';
 
 const GPT_TIMEOUT_MS = 10 * 1000;

--- a/src/platforms/shared/setup/labrador.setup.ts
+++ b/src/platforms/shared/setup/labrador.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	DiProcess,
 	InstantConfigCacheStorage,

--- a/src/platforms/shared/slots/slots-context.ts
+++ b/src/platforms/shared/slots/slots-context.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	communicationService,

--- a/src/platforms/shared/templates/handlers/advertisement-label-handler.ts
+++ b/src/platforms/shared/templates/handlers/advertisement-label-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, AdvertisementLabel, TEMPLATE, TemplateStateHandler } from '@wikia/ad-engine';
 import { Inject, Injectable } from '@wikia/dependency-injection';
 

--- a/src/platforms/shared/templates/handlers/bfaa/bfaa-bootstrap-handler.ts
+++ b/src/platforms/shared/templates/handlers/bfaa/bfaa-bootstrap-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	resolvedState,

--- a/src/platforms/shared/templates/handlers/bfab/bfab-bootstrap-handler.ts
+++ b/src/platforms/shared/templates/handlers/bfab/bfab-bootstrap-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	resolvedState,

--- a/src/platforms/shared/templates/handlers/close-to-hidden-button-handler.ts
+++ b/src/platforms/shared/templates/handlers/close-to-hidden-button-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	CloseButton,

--- a/src/platforms/shared/templates/handlers/close-to-hidden-ihi-button-handler.ts
+++ b/src/platforms/shared/templates/handlers/close-to-hidden-ihi-button-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	CloseButton,

--- a/src/platforms/shared/templates/handlers/close-to-transition-button-handler.ts
+++ b/src/platforms/shared/templates/handlers/close-to-transition-button-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	CloseButton,

--- a/src/platforms/shared/templates/handlers/interstitial/interstitial-bootstrap-handler.ts
+++ b/src/platforms/shared/templates/handlers/interstitial/interstitial-bootstrap-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	communicationService,

--- a/src/platforms/shared/templates/handlers/slot/slot-decision-on-viewability-handler.ts
+++ b/src/platforms/shared/templates/handlers/slot/slot-decision-on-viewability-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	InstantConfigService,

--- a/src/platforms/shared/templates/handlers/slot/slot-hidden-handler.ts
+++ b/src/platforms/shared/templates/handlers/slot/slot-hidden-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, AdSlotEvent, TEMPLATE, TemplateStateHandler } from '@wikia/ad-engine';
 import { Inject, Injectable } from '@wikia/dependency-injection';
 import { DomManipulator } from '../../helpers/manipulators/dom-manipulator';

--- a/src/platforms/shared/templates/handlers/slot/slot-transition-handler.ts
+++ b/src/platforms/shared/templates/handlers/slot/slot-transition-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	TEMPLATE,

--- a/src/platforms/shared/templates/handlers/slot/slot-transition-ihi-handler.ts
+++ b/src/platforms/shared/templates/handlers/slot/slot-transition-ihi-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	TEMPLATE,

--- a/src/platforms/shared/templates/handlers/sticky-tlb/sticky-tlb-blocking-handler.ts
+++ b/src/platforms/shared/templates/handlers/sticky-tlb/sticky-tlb-blocking-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	babDetection,

--- a/src/platforms/shared/templates/handlers/video/video-bootstrap-handler.ts
+++ b/src/platforms/shared/templates/handlers/video/video-bootstrap-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	AdSlotEvent,

--- a/src/platforms/shared/templates/handlers/video/video-learn-more-handler.ts
+++ b/src/platforms/shared/templates/handlers/video/video-learn-more-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PorvataPlayer, TemplateStateHandler } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { Subject } from 'rxjs';

--- a/src/platforms/shared/templates/helpers/close-button-helper.ts
+++ b/src/platforms/shared/templates/helpers/close-button-helper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, DomListener, TEMPLATE } from '@wikia/ad-engine';
 import { Inject, Injectable } from '@wikia/dependency-injection';
 import { from, Observable } from 'rxjs';

--- a/src/platforms/shared/templates/helpers/manipulators/dom-manipulator.ts
+++ b/src/platforms/shared/templates/helpers/manipulators/dom-manipulator.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Injectable } from '@wikia/dependency-injection';
 import { ElementManipulator } from './element-manipulator';
 

--- a/src/platforms/shared/templates/helpers/player-registry.ts
+++ b/src/platforms/shared/templates/helpers/player-registry.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	Porvata,

--- a/src/platforms/shared/templates/helpers/uap-dom-manager.ts
+++ b/src/platforms/shared/templates/helpers/uap-dom-manager.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	communicationService,

--- a/src/platforms/shared/templates/helpers/uap-dom-reader.ts
+++ b/src/platforms/shared/templates/helpers/uap-dom-reader.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, context, TEMPLATE, UapParams } from '@wikia/ad-engine';
 import { Inject, Injectable } from '@wikia/dependency-injection';
 import { NAVBAR } from '../configs/uap-dom-elements';

--- a/src/platforms/shared/templates/helpers/video-dom-manager.ts
+++ b/src/platforms/shared/templates/helpers/video-dom-manager.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PorvataPlayer, TEMPLATE, UapParams } from '@wikia/ad-engine';
 import { Inject, Injectable } from '@wikia/dependency-injection';
 import { DomManipulator } from './manipulators/dom-manipulator';

--- a/src/platforms/shared/templates/helpers/video-dom-reader.ts
+++ b/src/platforms/shared/templates/helpers/video-dom-reader.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TEMPLATE, UapParams, UapState } from '@wikia/ad-engine';
 import { Inject, Injectable } from '@wikia/dependency-injection';
 import { UapDomReader } from './uap-dom-reader';

--- a/src/platforms/shared/tracking/batch-processor.ts
+++ b/src/platforms/shared/tracking/batch-processor.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 interface Task {
 	[key: string]: string;
 }

--- a/src/platforms/shared/tracking/data-warehouse-utils/dw-aggregated-data-gzip-compressor.ts
+++ b/src/platforms/shared/tracking/data-warehouse-utils/dw-aggregated-data-gzip-compressor.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { utils } from '@wikia/ad-engine';
 import { Compressed, DwAggregatedDataCompressor } from './dw-aggregated-data-sender';
 

--- a/src/platforms/shared/tracking/data-warehouse-utils/dw-traffic-aggregator.ts
+++ b/src/platforms/shared/tracking/data-warehouse-utils/dw-traffic-aggregator.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from '@wikia/ad-engine';
 import { TrackingUrl } from '../../setup/tracking-urls';
 import { DataWarehouseParams } from '../data-warehouse';

--- a/src/platforms/shared/tracking/data-warehouse.ts
+++ b/src/platforms/shared/tracking/data-warehouse.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, targetingService, trackingOptIn, utils } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { AdEngineStageSetup } from '../setup/ad-engine-stage.setup';

--- a/src/platforms/shared/tracking/load-times-tracker.ts
+++ b/src/platforms/shared/tracking/load-times-tracker.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository, utils } from '@wikia/ad-engine';
 import { trackingUrls } from '../setup/tracking-urls';
 import { DataWarehouseTracker } from './data-warehouse';

--- a/src/platforms/shared/tracking/metric-reporter/metric-reporter-sender.ts
+++ b/src/platforms/shared/tracking/metric-reporter/metric-reporter-sender.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { context, utils } from '@wikia/ad-engine';
 
 interface EndpointInfo {

--- a/src/platforms/shared/tracking/tracking.setup.ts
+++ b/src/platforms/shared/tracking/tracking.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	adClickTracker,
 	Apstag,

--- a/src/platforms/shared/utils/collapsed-messages/message-box.ts
+++ b/src/platforms/shared/utils/collapsed-messages/message-box.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { communicationService, eventsRepository, type AdSlot } from '@wikia/ad-engine';
 import type { MessageBoxType } from './message-box-type';
 

--- a/src/platforms/shared/utils/insert-slots.ts
+++ b/src/platforms/shared/utils/insert-slots.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { SlotCreator, SlotCreatorConfig, SlotCreatorWrapperConfig, utils } from '@wikia/ad-engine';
 import { slotsContext } from '../slots/slots-context';
 

--- a/src/platforms/shared/utils/instant-config.setup.ts
+++ b/src/platforms/shared/utils/instant-config.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	communicationService,
 	context,

--- a/src/platforms/shared/utils/placeholder-service-helper.ts
+++ b/src/platforms/shared/utils/placeholder-service-helper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { AdSlot, AdSlotEvent, AdSlotStatus } from '@wikia/ad-engine';
 
 export class PlaceholderServiceHelper {

--- a/src/platforms/shared/utils/placeholder-service.ts
+++ b/src/platforms/shared/utils/placeholder-service.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlotEventPayload,
 	communicationService,

--- a/src/platforms/sports/templates/bfaa-template.ts
+++ b/src/platforms/sports/templates/bfaa-template.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdvertisementLabelHandler,
 	BfaaBootstrapHandler,

--- a/src/platforms/sports/templates/handlers/bfaa/bfaa-sports-config-handler.ts
+++ b/src/platforms/sports/templates/handlers/bfaa/bfaa-sports-config-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { slotsContext } from '@platforms/shared';
 import {
 	communicationService,

--- a/src/platforms/sports/templates/sports-templates.setup.ts
+++ b/src/platforms/sports/templates/sports-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';
 import { merge } from 'rxjs';

--- a/src/platforms/ucp-desktop/bidders/prebid/magniteS2s.ts
+++ b/src/platforms/ucp-desktop/bidders/prebid/magniteS2s.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export function getMagniteS2sContext(video = false): object {
 	const context = {
 		enabled: false,

--- a/src/platforms/ucp-desktop/modes/ucp-desktop-ads.mode.ts
+++ b/src/platforms/ucp-desktop/modes/ucp-desktop-ads.mode.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdEngineStackSetup,
 	GptSetup,

--- a/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-slots-definition-repository.ts
+++ b/src/platforms/ucp-desktop/setup/dynamic-slots/ucp-desktop-slots-definition-repository.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	activateFloorAdhesionOnUAP,
 	SlotsDefinitionRepository,

--- a/src/platforms/ucp-desktop/templates/ucp-desktop-templates.setup.ts
+++ b/src/platforms/ucp-desktop/templates/ucp-desktop-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { registerInterstitialTemplate, StickedBoxadHelper } from '@platforms/shared';
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';

--- a/src/platforms/ucp-desktop/utils/fmr-rotator.ts
+++ b/src/platforms/ucp-desktop/utils/fmr-rotator.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	AdSlotEvent,

--- a/src/platforms/ucp-mobile/modes/ucp-mobile-ads.mode.ts
+++ b/src/platforms/ucp-mobile/modes/ucp-mobile-ads.mode.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdEngineStackSetup,
 	GptSetup,

--- a/src/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-slots-definition-repository.ts
+++ b/src/platforms/ucp-mobile/setup/dynamic-slots/ucp-mobile-slots-definition-repository.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { activateFloorAdhesionOnUAP, SlotSetupDefinition } from '@platforms/shared';
 import {
 	AdSlot,

--- a/src/platforms/ucp-mobile/setup/experiments/ucp-mobile-top-boxad-experiment.ts
+++ b/src/platforms/ucp-mobile/setup/experiments/ucp-mobile-top-boxad-experiment.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	context,
 	defineExperiment,

--- a/src/platforms/ucp-mobile/setup/experiments/utils/ucp-mobile-top-boxad-paragraph-helper.ts
+++ b/src/platforms/ucp-mobile/setup/experiments/utils/ucp-mobile-top-boxad-paragraph-helper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Injectable } from '@wikia/dependency-injection';
 
 @Injectable()

--- a/src/platforms/ucp-mobile/templates/handlers/floor-adhesion/floor-adhesion-anchor-hidden-handler.ts
+++ b/src/platforms/ucp-mobile/templates/handlers/floor-adhesion/floor-adhesion-anchor-hidden-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DomManipulator } from '@platforms/shared';
 import { AdSlot, TemplateStateHandler } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';

--- a/src/platforms/ucp-mobile/templates/handlers/floor-adhesion/floor-adhesion-bootstrap-handler.ts
+++ b/src/platforms/ucp-mobile/templates/handlers/floor-adhesion/floor-adhesion-bootstrap-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	slotTweaker,

--- a/src/platforms/ucp-mobile/templates/handlers/floor-adhesion/floor-adhesion-close-button-handler.ts
+++ b/src/platforms/ucp-mobile/templates/handlers/floor-adhesion/floor-adhesion-close-button-handler.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
 	AdSlot,
 	CloseButton,

--- a/src/platforms/ucp-mobile/templates/ucp-mobile-templates.setup.ts
+++ b/src/platforms/ucp-mobile/templates/ucp-mobile-templates.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { registerInterstitialTemplate } from '@platforms/shared';
 import { DiProcess, logTemplates, TemplateRegistry, templateService } from '@wikia/ad-engine';
 import { Injectable } from '@wikia/dependency-injection';

--- a/src/platforms/ucp-no-ads/setup/wiki-context.setup.ts
+++ b/src/platforms/ucp-no-ads/setup/wiki-context.setup.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DiProcess, targetingService } from '@wikia/ad-engine';
 
 export class UcpNoAdsWikiContextSetup implements DiProcess {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
 		"importHelpers": true,
 		"lib": ["ESNext", "dom"],
 		"outDir": "dist",
-		"typeRoots": ["node_modules/@types", "node_modules/@alugha/ima", "@types"],
+		"typeRoots": ["node_modules/@types", "@types"],
 		"paths": {
 			// Unit tests
 			"@wikia/*": ["src/*"],
@@ -34,7 +34,12 @@
 			// Platforms
 			"@wikia/ad-engine": ["src/index.ts"],
 			"@platforms/shared": ["src/platforms/shared/index.ts"]
-		}
+		},
+		"plugins": [
+			{
+				"name": "typescript-strict-plugin"
+			}
+		]
 	},
 	"include": ["src", "spec"],
 	"exclude": ["@types", "node_modules", "**/dist/**/*"]


### PR DESCRIPTION
This PR enables TS strict mode for all new files and files that don't cause any TS error currently. All other files contain `// @ts-strict-ignore`. 